### PR TITLE
DEP: fix to deprecation warnings from collections

### DIFF
--- a/zipline/_protocol.pyx
+++ b/zipline/_protocol.pyx
@@ -19,7 +19,7 @@ import pandas as pd
 import numpy as np
 
 from cpython cimport bool
-from collections import Iterable
+from collections.abc import Iterable
 
 from zipline.assets import (
     PricingDataAssociable,

--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -12,7 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections import Iterable, namedtuple
+from collections.abc import Iterable
+from collections import namedtuple
 from copy import copy
 import warnings
 from datetime import tzinfo, time

--- a/zipline/pipeline/term.py
+++ b/zipline/pipeline/term.py
@@ -3,7 +3,7 @@ Base class for Filters, Factors and Classifiers
 """
 from abc import ABCMeta, abstractproperty, abstractmethod
 from bisect import insort
-from collections import Mapping
+from collections.abc import Mapping
 from weakref import WeakValueDictionary
 
 from numpy import (

--- a/zipline/utils/cache.py
+++ b/zipline/utils/cache.py
@@ -1,7 +1,7 @@
 """
 Caching utilities for zipline
 """
-from collections import MutableMapping
+from collections.abc import MutableMapping
 import errno
 from functools import partial
 import os

--- a/zipline/utils/memoize.py
+++ b/zipline/utils/memoize.py
@@ -1,7 +1,8 @@
 """
 Tools for memoization of function results.
 """
-from collections import OrderedDict, Sequence
+from collections.abc import Sequence
+from collections import OrderedDict
 from itertools import compress
 from weakref import WeakKeyDictionary, ref
 


### PR DESCRIPTION
Fix to the deprecation warnings: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working