### PR TITLE
MAINT: impose lower bound on pandas <=1.2.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ install_requires =
     networkx>=2.0
     numexpr>=2.6.1
     numpy>=1.14.5
-    pandas>=1.1.0
+    pandas>=1.1.0,<=1.2.5
     patsy>=0.4.0
     python-dateutil>=2.4.2
     python-interface>=1.5.3


### PR DESCRIPTION
Impose a lower bound on pandas <=1.2.5, otherwise zipline will fail with errors
This should fix the error, until trading_calendars is hopefully replaced

`NP_NAT = np.array([pd.NaT], dtype=np.int64)[0]
E   TypeError: int() argument must be a string, a bytes-like object or a number, not 'NaTType'`