### PR TITLE
MAINT: warnings maintenance

### DIFF
--- a/src/zipline/data/adjustments.py
+++ b/src/zipline/data/adjustments.py
@@ -387,9 +387,10 @@ class SQLiteAdjustmentWriter(object):
     def _write(self, tablename, expected_dtypes, frame):
         if frame is None or frame.empty:
             # keeping the dtypes correct for empty frames is not easy
-            frame = pd.DataFrame(
-                np.array([], dtype=list(expected_dtypes.items())),
-            )
+            # frame = pd.DataFrame(
+            #     np.array([], dtype=list(expected_dtypes.items())),
+            # )
+            frame = pd.DataFrame(expected_dtypes, index=[])
         else:
             if frozenset(frame.columns) != frozenset(expected_dtypes):
                 raise ValueError(

--- a/src/zipline/data/minute_bars.py
+++ b/src/zipline/data/minute_bars.py
@@ -67,9 +67,7 @@ class MinuteBarReader(BarReader):
 
 
 def _calc_minute_index(market_opens, minutes_per_day):
-    minutes = np.zeros(
-        len(market_opens) * minutes_per_day, dtype="datetime64[ns]"
-    )
+    minutes = np.zeros(len(market_opens) * minutes_per_day, dtype="datetime64[ns]")
     deltas = np.arange(0, minutes_per_day, dtype="timedelta64[m]")
     for i, market_open in enumerate(market_opens):
         start = market_open.asm8
@@ -228,22 +226,16 @@ class BcolzMinuteBarMetadata(object):
 
             if version >= 2:
                 calendar = get_calendar(raw_data["calendar_name"])
-                start_session = pd.Timestamp(
-                    raw_data["start_session"], tz="UTC"
-                )
+                start_session = pd.Timestamp(raw_data["start_session"], tz="UTC")
                 end_session = pd.Timestamp(raw_data["end_session"], tz="UTC")
             else:
                 # No calendar info included in older versions, so
                 # default to NYSE.
                 calendar = get_calendar("XNYS")
 
-                start_session = pd.Timestamp(
-                    raw_data["first_trading_day"], tz="UTC"
-                )
+                start_session = pd.Timestamp(raw_data["first_trading_day"], tz="UTC")
                 end_session = calendar.minute_to_session_label(
-                    pd.Timestamp(
-                        raw_data["market_closes"][-1], unit="m", tz="UTC"
-                    )
+                    pd.Timestamp(raw_data["market_closes"][-1], unit="m", tz="UTC")
                 )
 
             if version >= 3:
@@ -343,14 +335,10 @@ class BcolzMinuteBarMetadata(object):
             # Write these values for backwards compatibility
             "first_trading_day": str(self.start_session.date()),
             "market_opens": (
-                market_opens.values.astype("datetime64[m]")
-                .astype(np.int64)
-                .tolist()
+                market_opens.values.astype("datetime64[m]").astype(np.int64).tolist()
             ),
             "market_closes": (
-                market_closes.values.astype("datetime64[m]")
-                .astype(np.int64)
-                .tolist()
+                market_closes.values.astype("datetime64[m]").astype(np.int64).tolist()
             ),
         }
         with open(self.metadata_path(rootdir), "w+") as fp:
@@ -466,9 +454,7 @@ class BcolzMinuteBarWriter(object):
         self._start_session = start_session
         self._end_session = end_session
         self._calendar = calendar
-        slicer = calendar.schedule.index.slice_indexer(
-            start_session, end_session
-        )
+        slicer = calendar.schedule.index.slice_indexer(start_session, end_session)
         self._schedule = calendar.schedule[slicer]
         self._session_labels = self._schedule.index
         self._minutes_per_day = minutes_per_day
@@ -843,7 +829,7 @@ class BcolzMinuteBarWriter(object):
         vol_col = np.zeros(minutes_count, dtype=np.uint32)
 
         dt_ixs = np.searchsorted(
-            all_minutes_in_window.values, dts.astype("datetime64[ns]")
+            all_minutes_in_window.values, pd.Index(dts).tz_localize(None).values
         )
 
         ohlc_ratio = self.ohlc_ratio_for_sid(sid)
@@ -887,9 +873,7 @@ class BcolzMinuteBarWriter(object):
                 logger.info("{0} not past truncate date={1}.", file_name, date)
                 continue
 
-            logger.info(
-                "Truncating {0} at end_date={1}", file_name, date.date()
-            )
+            logger.info("Truncating {0} at end_date={1}", file_name, date.date())
 
             table.resize(truncate_slice_end)
 
@@ -964,9 +948,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
 
         self._minutes_per_day = metadata.minutes_per_day
 
-        self._carrays = {
-            field: LRU(sid_cache_sizes[field]) for field in self.FIELDS
-        }
+        self._carrays = {field: LRU(sid_cache_sizes[field]) for field in self.FIELDS}
 
         self._last_get_value_dt_position = None
         self._last_get_value_dt_value = None
@@ -1021,9 +1003,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
         market_opens = self._market_opens.values.astype("datetime64[m]")
         market_closes = self._market_closes.values.astype("datetime64[m]")
         minutes_per_day = (market_closes - market_opens).astype(np.int64)
-        early_indices = np.where(minutes_per_day != self._minutes_per_day - 1)[
-            0
-        ]
+        early_indices = np.where(minutes_per_day != self._minutes_per_day - 1)[0]
         early_opens = self._market_opens[early_indices]
         early_closes = self._market_closes[early_indices]
         minutes = [
@@ -1054,9 +1034,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
         for market_open, early_close in self._minutes_to_exclude():
             start_pos = self._find_position_of_minute(early_close) + 1
             end_pos = (
-                self._find_position_of_minute(market_open)
-                + self._minutes_per_day
-                - 1
+                self._find_position_of_minute(market_open) + self._minutes_per_day - 1
             )
             data = (start_pos, end_pos)
             itree[start_pos : end_pos + 1] = data
@@ -1269,9 +1247,7 @@ class BcolzMinuteBarReader(MinuteBarReader):
 
         results = []
 
-        indices_to_exclude = self._exclusion_indices_for_range(
-            start_idx, end_idx
-        )
+        indices_to_exclude = self._exclusion_indices_for_range(start_idx, end_idx)
         if indices_to_exclude is not None:
             for excl_start, excl_stop in indices_to_exclude:
                 length = excl_stop - excl_start + 1
@@ -1355,9 +1331,7 @@ class H5MinuteBarUpdateWriter(object):
     _COMPLIB = "zlib"
 
     def __init__(self, path, complevel=None, complib=None):
-        self._complevel = (
-            complevel if complevel is not None else self._COMPLEVEL
-        )
+        self._complevel = complevel if complevel is not None else self._COMPLEVEL
         self._complib = complib if complib is not None else self._COMPLIB
         self._path = path
 

--- a/src/zipline/data/resample.py
+++ b/src/zipline/data/resample.py
@@ -28,6 +28,7 @@ from zipline.data.bar_reader import NoDataOnDate
 from zipline.data.minute_bars import MinuteBarReader
 from zipline.data.session_bars import SessionBarReader
 from zipline.utils.memoize import lazyval
+from zipline.utils.math_utils import nanmax, nanmin
 
 _MINUTE_TO_SESSION_OHCLV_HOW = OrderedDict(
     (
@@ -270,9 +271,7 @@ class DailyHistoryAggregator(object):
                         highs.append(last_max)
                         continue
                     elif last_visited_dt == prev_dt:
-                        curr_val = self._minute_reader.get_value(
-                            asset, dt, "high"
-                        )
+                        curr_val = self._minute_reader.get_value(asset, dt, "high")
                         if pd.isnull(curr_val):
                             val = last_max
                         elif pd.isnull(last_max):
@@ -292,7 +291,7 @@ class DailyHistoryAggregator(object):
                             dt,
                             [asset],
                         )[0].T
-                        val = np.nanmax(np.append(window, last_max))
+                        val = nanmax(np.append(window, last_max))
                         entries[asset] = (dt_value, val)
                         highs.append(val)
                         continue
@@ -303,7 +302,7 @@ class DailyHistoryAggregator(object):
                         dt,
                         [asset],
                     )[0].T
-                    val = np.nanmax(window)
+                    val = nanmax(window)
                     entries[asset] = (dt_value, val)
                     highs.append(val)
                     continue
@@ -341,10 +340,8 @@ class DailyHistoryAggregator(object):
                         lows.append(last_min)
                         continue
                     elif last_visited_dt == prev_dt:
-                        curr_val = self._minute_reader.get_value(
-                            asset, dt, "low"
-                        )
-                        val = np.nanmin([last_min, curr_val])
+                        curr_val = self._minute_reader.get_value(asset, dt, "low")
+                        val = nanmin([last_min, curr_val])
                         entries[asset] = (dt_value, val)
                         lows.append(val)
                         continue
@@ -358,7 +355,7 @@ class DailyHistoryAggregator(object):
                             dt,
                             [asset],
                         )[0].T
-                        val = np.nanmin(np.append(window, last_min))
+                        val = nanmin(np.append(window, last_min))
                         entries[asset] = (dt_value, val)
                         lows.append(val)
                         continue
@@ -369,7 +366,7 @@ class DailyHistoryAggregator(object):
                         dt,
                         [asset],
                     )[0].T
-                    val = np.nanmin(window)
+                    val = nanmin(window)
                     entries[asset] = (dt_value, val)
                     lows.append(val)
                     continue
@@ -581,9 +578,7 @@ class MinuteResampleSessionBarReader(SessionBarReader):
     def sessions(self):
         cal = self._calendar
         first = self._minute_bar_reader.first_trading_day
-        last = cal.minute_to_session_label(
-            self._minute_bar_reader.last_available_dt
-        )
+        last = cal.minute_to_session_label(self._minute_bar_reader.last_available_dt)
         return cal.sessions_in_range(first, last)
 
     @lazyval

--- a/src/zipline/examples/momentum_pipeline.py
+++ b/src/zipline/examples/momentum_pipeline.py
@@ -46,7 +46,7 @@ def rebalance(context, data):
         order_target_percent(asset, -one_third)
 
     # Remove any assets that should no longer be in our portfolio.
-    portfolio_assets = longs | shorts
+    portfolio_assets = longs.union(shorts)
     positions = context.portfolio.positions
     for asset in positions.keys() - set(portfolio_assets):
         # This will fail if the asset was removed from our portfolio because it

--- a/src/zipline/finance/metrics/metric.py
+++ b/src/zipline/finance/metrics/metric.py
@@ -538,7 +538,9 @@ class _ClassicRiskMetrics(object):
         tzinfo = end_date.tzinfo
         end_date = end_date.tz_convert(None)
         for period_timestamp in months:
-            period = period_timestamp.to_period(freq="%dM" % months_per)
+            period = period_timestamp.tz_localize(None).to_period(
+                freq="%dM" % months_per
+            )
             if period.end_time > end_date:
                 break
 

--- a/tests/data/bundles/test_core.py
+++ b/tests/data/bundles/test_core.py
@@ -274,6 +274,7 @@ class BundleCoreTestCase(WithInstanceTmpDir, WithDefaultDateBounds, ZiplineTestC
             ],
         }, "volume"
 
+    @pytest.mark.filterwarnings("ignore: Overwriting bundle with name")
     def test_ingest_assets_versions(self):
         versions = (1, 2)
 

--- a/tests/data/test_minute_bars.py
+++ b/tests/data/test_minute_bars.py
@@ -103,23 +103,18 @@ class BcolzMinuteBarTestCase(
         self.writer.write_sid(sid, data)
 
         open_price = self.reader.get_value(sid, minute, "open")
-
         assert 10.0 == open_price
 
         high_price = self.reader.get_value(sid, minute, "high")
-
         assert 20.0 == high_price
 
         low_price = self.reader.get_value(sid, minute, "low")
-
         assert 30.0 == low_price
 
         close_price = self.reader.get_value(sid, minute, "close")
-
         assert 40.0 == close_price
 
         volume_price = self.reader.get_value(sid, minute, "volume")
-
         assert 50.0 == volume_price
 
     def test_precision_after_scaling(self):
@@ -739,7 +734,7 @@ class BcolzMinuteBarTestCase(
                 assert_array_equal(np.zeros(9), ohlcv_window[i][0])
 
     def test_write_cols(self):
-        minute_0 = self.market_opens[self.test_calendar_start]
+        minute_0 = self.market_opens[self.test_calendar_start].tz_localize(None)
         minute_1 = minute_0 + timedelta(minutes=1)
         sid = 1
         cols = {
@@ -794,7 +789,9 @@ class BcolzMinuteBarTestCase(
 
     def test_write_cols_mismatch_length(self):
         dts = pd.date_range(
-            self.market_opens[self.test_calendar_start], periods=2, freq="min"
+            self.market_opens[self.test_calendar_start].tz_localize(None),
+            periods=2,
+            freq="min",
         ).asi8.astype("datetime64[s]")
         sid = 1
         cols = {

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -112,6 +112,7 @@ class TestsExamplesTests:
 
     # some columns contain values with unique ids that will not be the same
 
+    @pytest.mark.filterwarnings("ignore: Matplotlib is currently using agg")
     @pytest.mark.parametrize(
         "benchmark_returns", [read_checked_in_benchmark_data(), None]
     )
@@ -136,9 +137,7 @@ class TestsExamplesTests:
         # Exclude positions column as the positions do not always have the
         # same order
         columns = [
-            column
-            for column in examples._cols_to_check
-            if column != "positions"
+            column for column in examples._cols_to_check if column != "positions"
         ]
         assert_equal(
             actual_perf[columns],


### PR DESCRIPTION
Some maintenance to remove deprecation warnings and other warning during tests

- filter out matplotlib warning during tests
- use tz_localize(None) instead of converting  to datetime64 to silence warning
- use nanmax and nanmin (bootleneck) in src/zipline/data/resample.py 
- changed the way empty dataframe is created in src/zipline/data/adjustments.py