### PR TITLE
BUG: fix enum pickling issue

### DIFF
--- a/src/zipline/finance/order.py
+++ b/src/zipline/finance/order.py
@@ -22,7 +22,7 @@ from zipline.assets import Asset
 from zipline.utils.input_validation import expect_types
 
 ORDER_STATUS = IntEnum(
-    "ORDER STATUS",
+    "ORDER_STATUS",
     [
         "OPEN",
         "FILLED",


### PR DESCRIPTION
Fixed the missing underscore that causes an error when trying to pickle using zipline CLI.
The CI failed but not because of the commit. It's impossible to restart unfortunately.