### PR TITLE
ENH: Add support for exchange-calendars and pandas > 1.2.5

### DIFF
--- a/docs/source/trading-calendars.rst
+++ b/docs/source/trading-calendars.rst
@@ -144,7 +144,7 @@ First we'll start off by importing some modules that will be useful to us.
   from pytz import timezone
 
   # for creating and registering our calendar
-  from trading_calendars import register_calendar, TradingCalendar
+  from zipline.utils.calendar_utils import register_calendar, TradingCalendar
   from zipline.utils.memoize import lazyval
 
 

--- a/src/zipline/__init__.py
+++ b/src/zipline/__init__.py
@@ -18,7 +18,7 @@ import numpy as np
 
 # This is *not* a place to dump arbitrary classes/modules for convenience,
 # it is a place to expose the public interfaces.
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from . import data
 from . import finance
@@ -37,7 +37,7 @@ from zipline.finance.blotter import Blotter
 # PERF: Fire a warning if calendars were instantiated during zipline import.
 # Having calendars doesn't break anything per-se, but it makes zipline imports
 # noticeably slower, which becomes particularly noticeable in the Zipline CLI.
-from trading_calendars.calendar_utils import global_calendar_dispatcher
+from zipline.utils.calendar_utils import global_calendar_dispatcher
 
 if global_calendar_dispatcher._calendars:
     import warnings

--- a/src/zipline/__main__.py
+++ b/src/zipline/__main__.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 import zipline
 from zipline.data import bundles as bundles_module
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 from zipline.utils.compat import wraps
 from zipline.utils.cli import Date, Timestamp
 from zipline.utils.run_algo import _run, BenchmarkSpec, load_extensions

--- a/src/zipline/algorithm.py
+++ b/src/zipline/algorithm.py
@@ -24,8 +24,7 @@ import numpy as np
 
 from itertools import chain, repeat
 
-from trading_calendars.utils.pandas_utils import days_at_time
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar, days_at_time
 
 from zipline._protocol import handle_non_market_minutes
 from zipline.errors import (

--- a/src/zipline/assets/_assets.pyx
+++ b/src/zipline/assets/_assets.pyx
@@ -34,7 +34,7 @@ from numpy cimport int64_t
 import warnings
 cimport numpy as np
 
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 
 # Users don't construct instances of this object, and embedding the signature

--- a/src/zipline/assets/continuous_futures.pyx
+++ b/src/zipline/assets/continuous_futures.pyx
@@ -34,7 +34,7 @@ from functools import partial
 from numpy import array, empty, iinfo
 from numpy cimport long_t, int64_t
 from pandas import Timestamp
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 import warnings
 
 

--- a/src/zipline/assets/exchange_info.py
+++ b/src/zipline/assets/exchange_info.py
@@ -1,4 +1,4 @@
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 
 class ExchangeInfo(object):

--- a/src/zipline/data/adjustments.py
+++ b/src/zipline/data/adjustments.py
@@ -549,6 +549,8 @@ class SQLiteAdjustmentWriter(object):
             dividend_payouts = None
         else:
             dividend_payouts = dividends.copy()
+            # TODO: Check if that's the right place for this fix for pandas > 1.2.5
+            dividend_payouts.fillna(np.datetime64("NaT"), inplace=True)
             dividend_payouts["ex_date"] = (
                 dividend_payouts["ex_date"]
                 .values.astype("datetime64[s]")

--- a/src/zipline/data/bcolz_daily_bars.py
+++ b/src/zipline/data/bcolz_daily_bars.py
@@ -35,7 +35,7 @@ from pandas import (
     Timestamp,
 )
 from toolz import compose
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.data.session_bars import CurrencyAwareSessionBarReader
 from zipline.data.bar_reader import (

--- a/src/zipline/data/bundles/core.py
+++ b/src/zipline/data/bundles/core.py
@@ -7,7 +7,7 @@ import warnings
 import click
 from logbook import Logger
 import pandas as pd
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 from toolz import curry, complement, take
 
 from ..adjustments import SQLiteAdjustmentReader, SQLiteAdjustmentWriter

--- a/src/zipline/data/bundles/csvdir.py
+++ b/src/zipline/data/bundles/csvdir.py
@@ -7,7 +7,7 @@ import sys
 from logbook import Logger, StreamHandler
 from numpy import empty
 from pandas import DataFrame, read_csv, Index, Timedelta, NaT
-from trading_calendars import register_calendar_alias
+from zipline.utils.calendar_utils import register_calendar_alias
 
 from zipline.utils.cli import maybe_show_progress
 

--- a/src/zipline/data/bundles/quandl.py
+++ b/src/zipline/data/bundles/quandl.py
@@ -10,7 +10,7 @@ from logbook import Logger
 import pandas as pd
 import requests
 from urllib.parse import urlencode
-from trading_calendars import register_calendar_alias
+from zipline.utils.calendar_utils import register_calendar_alias
 
 from . import core as bundles
 import numpy as np

--- a/src/zipline/data/in_memory_daily_bars.py
+++ b/src/zipline/data/in_memory_daily_bars.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from pandas import NaT
 
-from trading_calendars import TradingCalendar
+from zipline.utils.calendar_utils import TradingCalendar
 
 from zipline.data.bar_reader import OHLCV, NoDataOnDate, NoDataForSid
 from zipline.data.session_bars import CurrencyAwareSessionBarReader

--- a/src/zipline/data/minute_bars.py
+++ b/src/zipline/data/minute_bars.py
@@ -27,7 +27,7 @@ import numpy as np
 import pandas as pd
 from pandas import HDFStore
 from toolz import keymap, valmap
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.data._minute_bar_internal import (
     minute_value,

--- a/src/zipline/examples/__init__.py
+++ b/src/zipline/examples/__init__.py
@@ -2,7 +2,7 @@ from importlib import import_module
 import os
 
 from toolz import merge
-from trading_calendars import register_calendar, get_calendar
+from zipline.utils.calendar_utils import register_calendar, get_calendar
 
 from zipline import run_algorithm
 

--- a/src/zipline/pipeline/domain.py
+++ b/src/zipline/pipeline/domain.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 import pytz
 
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.country import CountryCode
 from zipline.utils.formatting import bulleted_list

--- a/src/zipline/testing/core.py
+++ b/src/zipline/testing/core.py
@@ -23,7 +23,7 @@ import pandas as pd
 from sqlalchemy import create_engine
 from testfixtures import TempDirectory
 from toolz import concat, curry
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.assets import AssetFinder, AssetDBWriter
 from zipline.assets.synthetic import make_simple_equity_info
@@ -129,9 +129,7 @@ def assert_single_position(test, zipline):
             test.zipline_test_config["expected_transactions"], transaction_count
         )
     else:
-        test.assertEqual(
-            test.zipline_test_config["order_count"], transaction_count
-        )
+        test.assertEqual(test.zipline_test_config["order_count"], transaction_count)
 
     # the final message is the risk report, the second to
     # last is the final day's results. Positions is a list of
@@ -151,9 +149,7 @@ def assert_single_position(test, zipline):
     for order in orders_by_id.value():
         test.assertEqual(order["status"], ORDER_STATUS.FILLED, "")
 
-    test.assertEqual(
-        len(closing_positions), 1, "Portfolio should have one position."
-    )
+    test.assertEqual(len(closing_positions), 1, "Portfolio should have one position.")
 
     sid = test.zipline_test_config["sid"]
     test.assertEqual(
@@ -185,8 +181,7 @@ def security_list_copy():
 def add_security_data(adds, deletes):
     if not hasattr(security_list, "using_copy"):
         raise Exception(
-            "add_security_data must be used within "
-            "security_list_copy context"
+            "add_security_data must be used within " "security_list_copy context"
         )
     directory = os.path.join(
         security_list.SECURITY_LISTS_DIR, "leveraged_etf_list/20150127/20150125"
@@ -275,9 +270,7 @@ def make_trade_data_for_asset_info(
     sids = asset_info.index
 
     price_sid_deltas = np.arange(len(sids), dtype=float64) * price_step_by_sid
-    price_date_deltas = (
-        np.arange(len(dates), dtype=float64) * price_step_by_date
-    )
+    price_date_deltas = np.arange(len(dates), dtype=float64) * price_step_by_date
     prices = (price_sid_deltas + as_column(price_date_deltas)) + price_start
 
     volume_sid_deltas = np.arange(len(sids)) * volume_step_by_sid
@@ -308,9 +301,7 @@ def make_trade_data_for_asset_info(
     return trade_data
 
 
-def check_allclose(
-    actual, desired, rtol=1e-07, atol=0, err_msg="", verbose=True
-):
+def check_allclose(actual, desired, rtol=1e-07, atol=0, err_msg="", verbose=True):
     """
     Wrapper around np.testing.assert_allclose that also verifies that inputs
     are ndarrays.
@@ -456,9 +447,7 @@ def create_data_portal(
     adjustment_reader=None,
 ):
     if sim_params.data_frequency == "daily":
-        daily_path = write_daily_data(
-            tempdir, sim_params, sids, trading_calendar
-        )
+        daily_path = write_daily_data(tempdir, sim_params, sids, trading_calendar)
 
         equity_daily_reader = BcolzDailyBarReader(daily_path)
 
@@ -474,9 +463,7 @@ def create_data_portal(
             sim_params.first_open, sim_params.last_close
         )
 
-        minute_path = write_minute_data(
-            trading_calendar, tempdir, minutes, sids
-        )
+        minute_path = write_minute_data(trading_calendar, tempdir, minutes, sids)
 
         equity_minute_reader = BcolzMinuteBarReader(minute_path)
 
@@ -503,9 +490,7 @@ def create_minute_df_for_asset(
     start_val=1,
     minute_blacklist=None,
 ):
-    asset_minutes = trading_calendar.minutes_for_sessions_in_range(
-        start_dt, end_dt
-    )
+    asset_minutes = trading_calendar.minutes_for_sessions_in_range(start_dt, end_dt)
     minutes_count = len(asset_minutes)
 
     if interval > 1:
@@ -672,9 +657,7 @@ def create_data_portal_from_trade_history(
 
 
 class FakeDataPortal(DataPortal):
-    def __init__(
-        self, asset_finder, trading_calendar=None, first_trading_day=None
-    ):
+    def __init__(self, asset_finder, trading_calendar=None, first_trading_day=None):
         if trading_calendar is None:
             trading_calendar = get_calendar("NYSE")
 
@@ -749,9 +732,7 @@ class FetcherDataPortal(DataPortal):
     # XXX: These aren't actually the methods that are used by the superclasses,
     # so these don't do anything, and this class will likely produce unexpected
     # results for history().
-    def _get_daily_window_for_sid(
-        self, asset, field, days_in_window, extra_slot=True
-    ):
+    def _get_daily_window_for_sid(self, asset, field, days_in_window, extra_slot=True):
         return np.arange(days_in_window, dtype=np.float64)
 
     def _get_minute_window_for_asset(self, asset, field, minutes_for_window):
@@ -779,9 +760,7 @@ class tmp_assets_db(object):
 
     _default_equities = sentinel("_default_equities")
 
-    def __init__(
-        self, url="sqlite:///:memory:", equities=_default_equities, **frames
-    ):
+    def __init__(self, url="sqlite:///:memory:", equities=_default_equities, **frames):
         self._url = url
         self._eng = None
         if equities is self._default_equities:
@@ -1374,9 +1353,7 @@ zipline_reloaded_git_root = abspath(
 
 # @nottest
 def test_resource_path(*path_parts):
-    return os.path.join(
-        zipline_reloaded_git_root, "tests", "resources", *path_parts
-    )
+    return os.path.join(zipline_reloaded_git_root, "tests", "resources", *path_parts)
 
 
 @contextmanager
@@ -1715,9 +1692,7 @@ def simulate_minutes_for_day(
 
     min_ = min(close, open_)
     where = values < min_
-    values[where] = (values[where] - min_) * (low - min_) / (
-        values.min() - min_
-    ) + min_
+    values[where] = (values[where] - min_) * (low - min_) / (values.min() - min_) + min_
 
     if not (np.allclose(values.max(), high) and np.allclose(values.min(), low)):
         return simulate_minutes_for_day(

--- a/src/zipline/testing/fixtures.py
+++ b/src/zipline/testing/fixtures.py
@@ -10,7 +10,7 @@ import pandas as pd
 from pandas.errors import PerformanceWarning
 import responses
 from toolz import flip, groupby, merge
-from trading_calendars import (
+from zipline.utils.calendar_utils import (
     get_calendar,
     register_calendar_alias,
 )

--- a/src/zipline/utils/calendar_utils.py
+++ b/src/zipline/utils/calendar_utils.py
@@ -2,47 +2,65 @@ from pytz import UTC
 import pandas as pd
 from functools import partial
 
-from trading_calendars import (
-    register_calendar,
-    TradingCalendar,
-    get_calendar,
-    register_calendar_alias,
+# from trading_calendars import (
+#     register_calendar,
+#     TradingCalendar,
+#     get_calendar,
+#     register_calendar_alias,
+# )
+# from trading_calendars.calendar_utils import global_calendar_dispatcher
+# from trading_calendars.utils.memoize import lazyval
+# from trading_calendars.utils.pandas_utils import days_at_time  # noqa: reexport
+
+from exchange_calendars import ExchangeCalendar as TradingCalendar
+from exchange_calendars.calendar_utils import (
+    ExchangeCalendarDispatcher,
+    _default_calendar_factories,
+    _default_calendar_aliases,
 )
-from trading_calendars.calendar_utils import global_calendar_dispatcher
-from trading_calendars.utils.memoize import lazyval
-from trading_calendars.utils.pandas_utils import days_at_time  # noqa: reexport
-
-# from exchange_calendars.calendar_utils import (
-#     ExchangeCalendarDispatcher,
-#     _default_calendar_factories,
-#     _default_calendar_aliases,
-# )
+from exchange_calendars.errors import InvalidCalendarName
+from exchange_calendars.utils.memoize import lazyval
+from exchange_calendars.utils.pandas_utils import days_at_time  # noqa: reexport
 
 
-# for k, v in _default_calendar_factories.items():
-#     if k in ["us_futures", "CMES", "XNYS"]:
-#         # TODO: I don't really like setting attribute like this
-#         setattr(v, "default_start", pd.Timestamp("1990-01-01", tz=UTC))
-#     if k not in ["us_futures", "24/7", "24/5", "CMES"]:
-#         v.open_times = [(d, t.replace(minute=t.minute + 1)) for d, t in v.open_times]
-#         _default_calendar_factories[k] = v
+def _fabricate(self, name: str, **kwargs):
+    """Fabricate calendar with `name` and `**kwargs`."""
+    try:
+        factory = self._calendar_factories[name]
+    except KeyError as e:
+        raise InvalidCalendarName(calendar_name=name) from e
+    if name in ["us_futures", "CMES", "XNYS"]:
+        # exchange_calendars has a different default start data
+        # that we need to overwrite in order to pass the legacy tests
+        setattr(factory, "default_start", pd.Timestamp("1990-01-01", tz=UTC))
+        # kwargs["start"] = pd.Timestamp("1990-01-01", tz="UTC")
+    # Zipline had default open time of t+1min
+    if name not in ["us_futures", "24/7", "24/5", "CMES"]:
+        factory.open_times = [
+            (d, t.replace(minute=t.minute + 1)) for d, t in factory.open_times
+        ]
+    calendar = factory(**kwargs)
+    self._factory_output_cache[name] = (calendar, kwargs)
+    return calendar
 
 
-# global_calendar_dispatcher = ExchangeCalendarDispatcher(
-#     calendars={},
-#     calendar_factories=_default_calendar_factories,
-#     aliases=_default_calendar_aliases,
-# )
+# Yay! Monkey patching
+ExchangeCalendarDispatcher._fabricate = _fabricate
 
-# # exchange_calendars has a different default start data that we need to overwrite
-# get_calendar = global_calendar_dispatcher.get_calendar
+global_calendar_dispatcher = ExchangeCalendarDispatcher(
+    calendars={},
+    calendar_factories=_default_calendar_factories,
+    aliases=_default_calendar_aliases,
+)
 
-# get_calendar_names = global_calendar_dispatcher.get_calendar_names
-# clear_calendars = global_calendar_dispatcher.clear_calendars
-# deregister_calendar = global_calendar_dispatcher.deregister_calendar
-# register_calendar = global_calendar_dispatcher.register_calendar
-# register_calendar_type = global_calendar_dispatcher.register_calendar_type
-# register_calendar_alias = global_calendar_dispatcher.register_calendar_alias
-# resolve_alias = global_calendar_dispatcher.resolve_alias
-# aliases_to_names = global_calendar_dispatcher.aliases_to_names
-# names_to_aliases = global_calendar_dispatcher.names_to_aliases
+get_calendar = global_calendar_dispatcher.get_calendar
+
+get_calendar_names = global_calendar_dispatcher.get_calendar_names
+clear_calendars = global_calendar_dispatcher.clear_calendars
+deregister_calendar = global_calendar_dispatcher.deregister_calendar
+register_calendar = global_calendar_dispatcher.register_calendar
+register_calendar_type = global_calendar_dispatcher.register_calendar_type
+register_calendar_alias = global_calendar_dispatcher.register_calendar_alias
+resolve_alias = global_calendar_dispatcher.resolve_alias
+aliases_to_names = global_calendar_dispatcher.aliases_to_names
+names_to_aliases = global_calendar_dispatcher.names_to_aliases

--- a/src/zipline/utils/calendar_utils.py
+++ b/src/zipline/utils/calendar_utils.py
@@ -1,66 +1,69 @@
 from pytz import UTC
 import pandas as pd
-from functools import partial
 
-# from trading_calendars import (
-#     register_calendar,
-#     TradingCalendar,
-#     get_calendar,
-#     register_calendar_alias,
-# )
-# from trading_calendars.calendar_utils import global_calendar_dispatcher
-# from trading_calendars.utils.memoize import lazyval
-# from trading_calendars.utils.pandas_utils import days_at_time  # noqa: reexport
+PANDAS_VERSION = pd.__version__
 
-from exchange_calendars import ExchangeCalendar as TradingCalendar
-from exchange_calendars.calendar_utils import (
-    ExchangeCalendarDispatcher,
-    _default_calendar_factories,
-    _default_calendar_aliases,
-)
-from exchange_calendars.errors import InvalidCalendarName
-from exchange_calendars.utils.memoize import lazyval
-from exchange_calendars.utils.pandas_utils import days_at_time  # noqa: reexport
+try:
+    from exchange_calendars import ExchangeCalendar as TradingCalendar
+    from exchange_calendars.calendar_utils import (
+        ExchangeCalendarDispatcher,
+        _default_calendar_factories,
+        _default_calendar_aliases,
+    )
+    from exchange_calendars.errors import InvalidCalendarName
+    from exchange_calendars.utils.memoize import lazyval
+    from exchange_calendars.utils.pandas_utils import days_at_time  # noqa: reexport
 
+    def _fabricate(self, name: str, **kwargs):
+        """Fabricate calendar with `name` and `**kwargs`."""
+        try:
+            factory = self._calendar_factories[name]
+        except KeyError as e:
+            raise InvalidCalendarName(calendar_name=name) from e
+        if name in ["us_futures", "CMES", "XNYS"]:
+            # exchange_calendars has a different default start data
+            # that we need to overwrite in order to pass the legacy tests
+            setattr(factory, "default_start", pd.Timestamp("1990-01-01", tz=UTC))
+            # kwargs["start"] = pd.Timestamp("1990-01-01", tz="UTC")
+        # Zipline had default open time of t+1min
+        if name not in ["us_futures", "24/7", "24/5", "CMES"]:
+            factory.open_times = [
+                (d, t.replace(minute=t.minute + 1)) for d, t in factory.open_times
+            ]
+        calendar = factory(**kwargs)
+        self._factory_output_cache[name] = (calendar, kwargs)
+        return calendar
 
-def _fabricate(self, name: str, **kwargs):
-    """Fabricate calendar with `name` and `**kwargs`."""
-    try:
-        factory = self._calendar_factories[name]
-    except KeyError as e:
-        raise InvalidCalendarName(calendar_name=name) from e
-    if name in ["us_futures", "CMES", "XNYS"]:
-        # exchange_calendars has a different default start data
-        # that we need to overwrite in order to pass the legacy tests
-        setattr(factory, "default_start", pd.Timestamp("1990-01-01", tz=UTC))
-        # kwargs["start"] = pd.Timestamp("1990-01-01", tz="UTC")
-    # Zipline had default open time of t+1min
-    if name not in ["us_futures", "24/7", "24/5", "CMES"]:
-        factory.open_times = [
-            (d, t.replace(minute=t.minute + 1)) for d, t in factory.open_times
-        ]
-    calendar = factory(**kwargs)
-    self._factory_output_cache[name] = (calendar, kwargs)
-    return calendar
+    # Yay! Monkey patching
+    ExchangeCalendarDispatcher._fabricate = _fabricate
 
+    global_calendar_dispatcher = ExchangeCalendarDispatcher(
+        calendars={},
+        calendar_factories=_default_calendar_factories,
+        aliases=_default_calendar_aliases,
+    )
+    get_calendar = global_calendar_dispatcher.get_calendar
 
-# Yay! Monkey patching
-ExchangeCalendarDispatcher._fabricate = _fabricate
+    get_calendar_names = global_calendar_dispatcher.get_calendar_names
+    clear_calendars = global_calendar_dispatcher.clear_calendars
+    deregister_calendar = global_calendar_dispatcher.deregister_calendar
+    register_calendar = global_calendar_dispatcher.register_calendar
+    register_calendar_type = global_calendar_dispatcher.register_calendar_type
+    register_calendar_alias = global_calendar_dispatcher.register_calendar_alias
+    resolve_alias = global_calendar_dispatcher.resolve_alias
+    aliases_to_names = global_calendar_dispatcher.aliases_to_names
+    names_to_aliases = global_calendar_dispatcher.names_to_aliases
 
-global_calendar_dispatcher = ExchangeCalendarDispatcher(
-    calendars={},
-    calendar_factories=_default_calendar_factories,
-    aliases=_default_calendar_aliases,
-)
-
-get_calendar = global_calendar_dispatcher.get_calendar
-
-get_calendar_names = global_calendar_dispatcher.get_calendar_names
-clear_calendars = global_calendar_dispatcher.clear_calendars
-deregister_calendar = global_calendar_dispatcher.deregister_calendar
-register_calendar = global_calendar_dispatcher.register_calendar
-register_calendar_type = global_calendar_dispatcher.register_calendar_type
-register_calendar_alias = global_calendar_dispatcher.register_calendar_alias
-resolve_alias = global_calendar_dispatcher.resolve_alias
-aliases_to_names = global_calendar_dispatcher.aliases_to_names
-names_to_aliases = global_calendar_dispatcher.names_to_aliases
+except ImportError:
+    if PANDAS_VERSION > "1.2.5":
+        raise ImportError("For pandas >= 1.3 YOU MUST INSTALL exchange-calendars")
+    else:
+        from trading_calendars import (
+            register_calendar,
+            TradingCalendar,
+            get_calendar,
+            register_calendar_alias,
+        )
+        from trading_calendars.calendar_utils import global_calendar_dispatcher
+        from trading_calendars.utils.memoize import lazyval
+        from trading_calendars.utils.pandas_utils import days_at_time  # noqa: reexport

--- a/src/zipline/utils/calendar_utils.py
+++ b/src/zipline/utils/calendar_utils.py
@@ -17,9 +17,8 @@ PANDAS_VERSION = pd.__version__
 # all imports should be done via `calendar_utils`, e.g:
 # `from zipline.utils.calendar_utils import get_calendar, register_calendar, ...`
 #
-# Some calendars like for instance the Korean exchange have been extensively updated.
-#
-
+# Some calendars like for instance the Korean exchange have been extensively updated and might no longer
+# work as expected
 
 try:
     from exchange_calendars import ExchangeCalendar as TradingCalendar

--- a/src/zipline/utils/calendar_utils.py
+++ b/src/zipline/utils/calendar_utils.py
@@ -1,0 +1,48 @@
+from pytz import UTC
+import pandas as pd
+from functools import partial
+
+from trading_calendars import (
+    register_calendar,
+    TradingCalendar,
+    get_calendar,
+    register_calendar_alias,
+)
+from trading_calendars.calendar_utils import global_calendar_dispatcher
+from trading_calendars.utils.memoize import lazyval
+from trading_calendars.utils.pandas_utils import days_at_time  # noqa: reexport
+
+# from exchange_calendars.calendar_utils import (
+#     ExchangeCalendarDispatcher,
+#     _default_calendar_factories,
+#     _default_calendar_aliases,
+# )
+
+
+# for k, v in _default_calendar_factories.items():
+#     if k in ["us_futures", "CMES", "XNYS"]:
+#         # TODO: I don't really like setting attribute like this
+#         setattr(v, "default_start", pd.Timestamp("1990-01-01", tz=UTC))
+#     if k not in ["us_futures", "24/7", "24/5", "CMES"]:
+#         v.open_times = [(d, t.replace(minute=t.minute + 1)) for d, t in v.open_times]
+#         _default_calendar_factories[k] = v
+
+
+# global_calendar_dispatcher = ExchangeCalendarDispatcher(
+#     calendars={},
+#     calendar_factories=_default_calendar_factories,
+#     aliases=_default_calendar_aliases,
+# )
+
+# # exchange_calendars has a different default start data that we need to overwrite
+# get_calendar = global_calendar_dispatcher.get_calendar
+
+# get_calendar_names = global_calendar_dispatcher.get_calendar_names
+# clear_calendars = global_calendar_dispatcher.clear_calendars
+# deregister_calendar = global_calendar_dispatcher.deregister_calendar
+# register_calendar = global_calendar_dispatcher.register_calendar
+# register_calendar_type = global_calendar_dispatcher.register_calendar_type
+# register_calendar_alias = global_calendar_dispatcher.register_calendar_alias
+# resolve_alias = global_calendar_dispatcher.resolve_alias
+# aliases_to_names = global_calendar_dispatcher.aliases_to_names
+# names_to_aliases = global_calendar_dispatcher.names_to_aliases

--- a/src/zipline/utils/factory.py
+++ b/src/zipline/utils/factory.py
@@ -20,7 +20,7 @@ Factory functions to prepare useful data.
 import pandas as pd
 import numpy as np
 from datetime import timedelta, datetime
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.sources import SpecificEquityTrades
 from zipline.finance.trading import SimulationParameters

--- a/src/zipline/utils/memoize.py
+++ b/src/zipline/utils/memoize.py
@@ -8,7 +8,7 @@ from weakref import WeakKeyDictionary, ref
 
 from _thread import allocate_lock as Lock
 from toolz.sandbox import unzip
-from trading_calendars.utils.memoize import lazyval
+from zipline.utils.calendar_utils import lazyval
 
 from zipline.utils.compat import wraps
 

--- a/src/zipline/utils/pandas_utils.py
+++ b/src/zipline/utils/pandas_utils.py
@@ -10,7 +10,7 @@ import warnings
 import numpy as np
 import pandas as pd
 from distutils.version import StrictVersion
-from trading_calendars.utils.pandas_utils import days_at_time  # noqa: reexport
+from zipline.utils.calendar_utils import days_at_time
 from pandas.errors import PerformanceWarning
 
 pandas_version = StrictVersion(pd.__version__)
@@ -337,7 +337,5 @@ def check_indexes_all_same(indexes, message="Indexes are not equal."):
             bad_loc = np.flatnonzero(~same)[0]
             raise ValueError(
                 "{}\nFirst difference is at index {}: "
-                "{} != {}".format(
-                    message, bad_loc, first[bad_loc], other[bad_loc]
-                ),
+                "{} != {}".format(message, bad_loc, first[bad_loc], other[bad_loc]),
             )

--- a/src/zipline/utils/run_algo.py
+++ b/src/zipline/utils/run_algo.py
@@ -14,7 +14,7 @@ except ImportError:
 import logbook
 import pandas as pd
 from toolz import concatv
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.data import bundles
 from zipline.data.benchmarks import get_benchmark_returns_from_file

--- a/tests/data/bundles/test_core.py
+++ b/tests/data/bundles/test_core.py
@@ -8,7 +8,7 @@ import pandas as pd
 import sqlalchemy as sa
 from toolz import valmap
 import toolz.curried.operator as op
-from trading_calendars import TradingCalendar, get_calendar
+from zipline.utils.calendar_utils import TradingCalendar, get_calendar
 
 from zipline.assets import ASSET_DB_VERSION
 

--- a/tests/data/bundles/test_csvdir.py
+++ b/tests/data/bundles/test_csvdir.py
@@ -7,7 +7,7 @@ from os.path import (
     realpath,
 )
 
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.data.bundles import ingest, load, bundles
 from zipline.utils.functional import apply

--- a/tests/data/bundles/test_quandl.py
+++ b/tests/data/bundles/test_quandl.py
@@ -7,7 +7,7 @@ from os.path import (
     realpath,
 )
 
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 from zipline.data.bundles import ingest, load, bundles
 from zipline.data.bundles.quandl import format_metadata_url, load_data_table
 from zipline.lib.adjustment import Float64Multiply
@@ -48,9 +48,7 @@ class QuandlBundleTestCase(WithResponses, ZiplineTestCase):
 
         # Load raw data from quandl test resources.
         data = load_data_table(
-            file=join(
-                TEST_RESOURCE_PATH, "quandl_samples", "QUANDL_ARCHIVE.zip"
-            ),
+            file=join(TEST_RESOURCE_PATH, "quandl_samples", "QUANDL_ARCHIVE.zip"),
             index_col="date",
         )
         data["sid"] = pd.factorize(data.symbol)[0]
@@ -71,9 +69,7 @@ class QuandlBundleTestCase(WithResponses, ZiplineTestCase):
                 yield vs
 
         # the first index our written data will appear in the files on disk
-        start_idx = (
-            self.calendar.all_sessions.get_loc(self.start_date, "ffill") + 1
-        )
+        start_idx = self.calendar.all_sessions.get_loc(self.start_date, "ffill") + 1
 
         # convert an index into the raw dataframe into an index into the
         # final data
@@ -83,8 +79,7 @@ class QuandlBundleTestCase(WithResponses, ZiplineTestCase):
             sid = sids[symbol]
             return (
                 1
-                - all_.iloc[idx]["ex_dividend", sid]
-                / all_.iloc[idx - 1]["close", sid]
+                - all_.iloc[idx]["ex_dividend", sid] / all_.iloc[idx - 1]["close", sid]
             )
 
         adjustments = [
@@ -232,9 +227,7 @@ class QuandlBundleTestCase(WithResponses, ZiplineTestCase):
         expected_pricing, expected_adjustments = self._expected_data(
             bundle.asset_finder,
         )
-        np.testing.assert_array_almost_equal(
-            actual, expected_pricing, decimal=2
-        )
+        np.testing.assert_array_almost_equal(actual, expected_pricing, decimal=2)
 
         adjs_for_cols = bundle.adjustment_reader.load_pricing_adjustments(
             self.columns,

--- a/tests/data/test_daily_bars.py
+++ b/tests/data/test_daily_bars.py
@@ -20,7 +20,7 @@ from parameterized import parameterized
 import numpy as np
 import pandas as pd
 from toolz import merge
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.data.bar_reader import (
     NoDataAfterDate,

--- a/tests/events/test_events.py
+++ b/tests/events/test_events.py
@@ -19,7 +19,7 @@ import warnings
 
 from parameterized import parameterized
 import pandas as pd
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 import zipline.utils.events
 from zipline.utils.events import (
@@ -247,9 +247,10 @@ class RuleTestCase:
             and not isabstract(v)
         }
         ds = {k[5:] for k in dir(self) if k.startswith("test") and k[5:] in dem}
-        assert dem <= ds, (
-            "This suite is missing tests for the following classes:\n"
-            + "\n".join(map(repr, dem - ds))
+        assert (
+            dem <= ds
+        ), "This suite is missing tests for the following classes:\n" + "\n".join(
+            map(repr, dem - ds)
         )
 
 
@@ -343,9 +344,7 @@ class StatelessRulesTests(RuleTestCase):
         """
         rule = NthTradingDayOfWeek(0)
         rule.cal = self.cal
-        first_open = self.cal.open_and_close_for_session(
-            self.cal.all_sessions[0]
-        )
+        first_open = self.cal.open_and_close_for_session(self.cal.all_sessions[0])
         assert first_open
 
     def test_NthTradingDayOfWeek(self):
@@ -375,9 +374,7 @@ class StatelessRulesTests(RuleTestCase):
             for minute in self.sept_week:
                 if should_trigger(minute):
                     n_tdays = 0
-                    session = self.cal.minute_to_session_label(
-                        minute, direction="none"
-                    )
+                    session = self.cal.minute_to_session_label(minute, direction="none")
                     next_session = self.cal.next_session_label(session)
                     while next_session.dayofweek > session.dayofweek:
                         session = next_session

--- a/tests/history/generate_csvs.py
+++ b/tests/history/generate_csvs.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 
 from zipline.data import BcolzMinuteBarWriter
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 
 def generate_daily_test_data(
@@ -91,9 +91,7 @@ def generate_minute_test_data(
     :return: None
     """
 
-    full_minutes = BcolzMinuteBarWriter.full_minutes_for_days(
-        first_day, last_day
-    )
+    full_minutes = BcolzMinuteBarWriter.full_minutes_for_days(first_day, last_day)
     minutes_count = len(full_minutes)
 
     cal = get_calendar("XNYS")

--- a/tests/pipeline/test_domain.py
+++ b/tests/pipeline/test_domain.py
@@ -70,6 +70,62 @@ from zipline.utils.pandas_utils import days_at_time
 import pytest
 import re
 
+EXPECTED_CUTOFF_TIMES = {
+    AR_EQUITIES: datetime.time(10, 15),
+    AT_EQUITIES: datetime.time(8, 15),
+    AU_EQUITIES: datetime.time(9, 15),
+    BE_EQUITIES: datetime.time(8, 15),
+    BR_EQUITIES: datetime.time(9, 15),
+    CA_EQUITIES: datetime.time(8, 45),
+    CH_EQUITIES: datetime.time(8, 15),
+    CL_EQUITIES: datetime.time(8, 45),
+    CN_EQUITIES: datetime.time(8, 45),
+    CO_EQUITIES: datetime.time(8, 45),
+    CZ_EQUITIES: datetime.time(8, 15),
+    DE_EQUITIES: datetime.time(8, 15),
+    DK_EQUITIES: datetime.time(8, 15),
+    ES_EQUITIES: datetime.time(8, 15),
+    FI_EQUITIES: datetime.time(9, 15),
+    FR_EQUITIES: datetime.time(8, 15),
+    GB_EQUITIES: datetime.time(7, 15),
+    GR_EQUITIES: datetime.time(9, 15),
+    HK_EQUITIES: datetime.time(9, 15),
+    HU_EQUITIES: datetime.time(8, 15),
+    ID_EQUITIES: datetime.time(8, 15),
+    IE_EQUITIES: datetime.time(7, 15),
+    IN_EQUITIES: datetime.time(8, 30),
+    IT_EQUITIES: datetime.time(8, 15),
+    JP_EQUITIES: datetime.time(8, 15),
+    KR_EQUITIES: datetime.time(8, 15),
+    MX_EQUITIES: datetime.time(7, 45),
+    MY_EQUITIES: datetime.time(8, 15),
+    NL_EQUITIES: datetime.time(8, 15),
+    NO_EQUITIES: datetime.time(8, 15),
+    NZ_EQUITIES: datetime.time(9, 15),
+    PE_EQUITIES: datetime.time(8, 15),
+    PH_EQUITIES: datetime.time(8, 45),
+    PK_EQUITIES: datetime.time(8, 47),
+    PL_EQUITIES: datetime.time(8, 15),
+    PT_EQUITIES: datetime.time(7, 15),
+    RU_EQUITIES: datetime.time(9, 15),
+    SE_EQUITIES: datetime.time(8, 15),
+    SG_EQUITIES: datetime.time(8, 15),
+    TH_EQUITIES: datetime.time(9, 15),
+    TR_EQUITIES: datetime.time(9, 15),
+    TW_EQUITIES: datetime.time(8, 15),
+    US_EQUITIES: datetime.time(8, 45),
+    ZA_EQUITIES: datetime.time(8, 15),
+}
+
+LIST_EXPECTED_CUTOFF_TIMES = list(EXPECTED_CUTOFF_TIMES.items())
+# KR is expected to fail
+LIST_EXPECTED_CUTOFF_TIMES[25] = pytest.param(
+    *LIST_EXPECTED_CUTOFF_TIMES[25],
+    marks=pytest.mark.xfail(
+        reason="The KR calendar is expected to fail TOFIX or remove"
+    ),
+)
+
 
 class Sum(CustomFactor):
     def compute(self, today, assets, out, data):
@@ -89,7 +145,6 @@ class MixedGenericsTestCase(zf.WithSeededRandomPipelineEngine, zf.ZiplineTestCas
     def test_mixed_generics(self):
         """
         Test that we can run pipelines with mixed generic/non-generic terms.
-
         This test is a regression test for failures encountered during
         development where having a mix of generic and non-generic columns in
         the term graph caused bugs in our extra row accounting.
@@ -350,63 +405,27 @@ class TestDataQueryCutoffForSession:
             expected_cutoff_date_offset,
         )
         actual = domain.data_query_cutoff_for_sessions(sessions)
-
         assert_equal(actual, expected, check_names=False)
 
-    def test_built_in_equity_calendar_domain_defaults(self):
-        # test the defaults
-        expected_cutoff_times = {
-            AR_EQUITIES: datetime.time(10, 15),
-            AT_EQUITIES: datetime.time(8, 15),
-            AU_EQUITIES: datetime.time(9, 15),
-            BE_EQUITIES: datetime.time(8, 15),
-            BR_EQUITIES: datetime.time(9, 15),
-            CA_EQUITIES: datetime.time(8, 45),
-            CH_EQUITIES: datetime.time(8, 15),
-            CL_EQUITIES: datetime.time(8, 45),
-            CN_EQUITIES: datetime.time(8, 45),
-            CO_EQUITIES: datetime.time(8, 45),
-            CZ_EQUITIES: datetime.time(8, 15),
-            DE_EQUITIES: datetime.time(8, 15),
-            DK_EQUITIES: datetime.time(8, 15),
-            ES_EQUITIES: datetime.time(8, 15),
-            FI_EQUITIES: datetime.time(9, 15),
-            FR_EQUITIES: datetime.time(8, 15),
-            GB_EQUITIES: datetime.time(7, 15),
-            GR_EQUITIES: datetime.time(9, 15),
-            HK_EQUITIES: datetime.time(9, 15),
-            HU_EQUITIES: datetime.time(8, 15),
-            ID_EQUITIES: datetime.time(8, 15),
-            IE_EQUITIES: datetime.time(7, 15),
-            IN_EQUITIES: datetime.time(8, 30),
-            IT_EQUITIES: datetime.time(8, 15),
-            JP_EQUITIES: datetime.time(8, 15),
-            KR_EQUITIES: datetime.time(8, 15),
-            MX_EQUITIES: datetime.time(7, 45),
-            MY_EQUITIES: datetime.time(8, 15),
-            NL_EQUITIES: datetime.time(8, 15),
-            NO_EQUITIES: datetime.time(8, 15),
-            NZ_EQUITIES: datetime.time(9, 15),
-            PE_EQUITIES: datetime.time(8, 15),
-            PH_EQUITIES: datetime.time(8, 45),
-            PK_EQUITIES: datetime.time(8, 47),
-            PL_EQUITIES: datetime.time(8, 15),
-            PT_EQUITIES: datetime.time(7, 15),
-            RU_EQUITIES: datetime.time(9, 15),
-            SE_EQUITIES: datetime.time(8, 15),
-            SG_EQUITIES: datetime.time(8, 15),
-            TH_EQUITIES: datetime.time(9, 15),
-            TR_EQUITIES: datetime.time(9, 15),
-            TW_EQUITIES: datetime.time(8, 15),
-            US_EQUITIES: datetime.time(8, 45),
-            ZA_EQUITIES: datetime.time(8, 15),
-        }
-
+    def test_assert_no_missing_domains(self):
         # make sure we are not missing any domains in this test
-        assert set(expected_cutoff_times) == set(BUILT_IN_DOMAINS)
+        assert set(EXPECTED_CUTOFF_TIMES) == set(BUILT_IN_DOMAINS)
 
-        for domain, expected_cutoff_time in expected_cutoff_times.items():
-            self._test_equity_calendar_domain(domain, expected_cutoff_time)
+    def idfn(val):
+        if isinstance(val, str):
+            return val
+
+    @pytest.mark.parametrize(
+        "domain, expected_cutoff_time",
+        LIST_EXPECTED_CUTOFF_TIMES,
+        ids=[
+            f"{x[0].calendar_name} {x[1]}" for x in list(EXPECTED_CUTOFF_TIMES.items())
+        ],
+    )
+    def test_built_in_equity_calendar_domain_defaults(
+        self, domain, expected_cutoff_time
+    ):
+        self._test_equity_calendar_domain(domain, expected_cutoff_time)
 
     def test_equity_calendar_domain(self):
         # test non-default time

--- a/tests/pipeline/test_frameload.py
+++ b/tests/pipeline/test_frameload.py
@@ -5,7 +5,7 @@ from mock import patch
 import numpy as np
 import pandas as pd
 from numpy.testing import assert_array_equal
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.lib.adjustment import (
     ADD,

--- a/tests/pipeline/test_international_markets.py
+++ b/tests/pipeline/test_international_markets.py
@@ -6,7 +6,7 @@ from parameterized import parameterized
 import numpy as np
 import pandas as pd
 
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.assets.synthetic import make_rotating_equity_info
 from zipline.data.in_memory_daily_bars import InMemoryDailyBarReader

--- a/tests/pipeline/test_pipeline_algo.py
+++ b/tests/pipeline/test_pipeline_algo.py
@@ -11,7 +11,7 @@ from parameterized import parameterized
 import numpy as np
 from numpy.testing import assert_almost_equal
 import pandas as pd
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.api import (
     attach_pipeline,

--- a/tests/resources/yahoo_samples/rebuild_samples
+++ b/tests/resources/yahoo_samples/rebuild_samples
@@ -6,51 +6,60 @@ from textwrap import dedent
 
 import numpy as np
 import pandas as pd
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 
 from zipline.testing import test_resource_path, write_compressed
 
 
 def zipfile_path(symbol, ext):
-    return test_resource_path('yahoo_samples', symbol + ext + '.gz')
+    return test_resource_path("yahoo_samples", symbol + ext + ".gz")
 
 
 def pricing_for_sid(sid):
     modifier = {
-        'Low': 0,
-        'Open': 1,
-        'Close': 2,
-        'High': 3,
-        'Volume': 0,
+        "Low": 0,
+        "Open": 1,
+        "Close": 2,
+        "High": 3,
+        "Volume": 0,
     }
 
     def column(name):
         return np.arange(252) + 1 + sid * 10000 + modifier[name] * 1000
 
-    trading_days = get_calendar('XNYS').all_sessions
+    trading_days = get_calendar("XNYS").all_sessions
 
-    return pd.DataFrame(
-        data={
-            'Date': trading_days[
-                (trading_days >= pd.Timestamp('2014')) &
-                (trading_days < pd.Timestamp('2015'))
+    return (
+        pd.DataFrame(
+            data={
+                "Date": trading_days[
+                    (trading_days >= pd.Timestamp("2014"))
+                    & (trading_days < pd.Timestamp("2015"))
+                ],
+                "Open": column("Open"),
+                "High": column("High"),
+                "Low": column("Low"),
+                "Close": column("Close"),
+                "Volume": column("Volume"),
+                "Adj Close": 0,
+            },
+            columns=[
+                "Date",
+                "Open",
+                "High",
+                "Low",
+                "Close",
+                "Volume",
+                "Adj Close",
             ],
-            'Open': column('Open'),
-            'High': column('High'),
-            'Low': column('Low'),
-            'Close': column('Close'),
-            'Volume': column('Volume'),
-            'Adj Close': 0,
-        },
-        columns=[
-            'Date', 'Open', 'High', 'Low', 'Close', 'Volume', 'Adj Close',
-        ],
-    ).to_csv(index=False, date_format='%Y-%m-%d').encode('ascii')
+        )
+        .to_csv(index=False, date_format="%Y-%m-%d")
+        .encode("ascii")
+    )
 
 
 def adjustments_for_sid(sid):
-    """This is not exactly a csv... thanks yahoo.
-    """
+    """This is not exactly a csv... thanks yahoo."""
     return dedent(
         """\
         Date,Dividends
@@ -60,22 +69,25 @@ def adjustments_for_sid(sid):
         STARTDATE, 20140102
         ENDDATE, 20141231
         TOTALSIZE, 2
-        """.format(p1=sid + 1, p2=sid + 2),
-    ).encode('ascii')
+        """.format(
+            p1=sid + 1, p2=sid + 2
+        ),
+    ).encode("ascii")
 
 
 def main():
-    symbols = 'AAPL', 'IBM', 'MSFT'
+    symbols = "AAPL", "IBM", "MSFT"
 
     for sid, symbol in enumerate(symbols):
         write_compressed(
-            zipfile_path(symbol, '.csv'),
+            zipfile_path(symbol, ".csv"),
             pricing_for_sid(sid),
         )
         write_compressed(
-            zipfile_path(symbol, '.adjustments'),
+            zipfile_path(symbol, ".adjustments"),
             adjustments_for_sid(sid),
         )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -29,7 +29,7 @@ from testfixtures import TempDirectory
 import numpy as np
 import pandas as pd
 import pytz
-from trading_calendars import get_calendar, register_calendar
+from zipline.utils.calendar_utils import get_calendar, register_calendar
 
 import zipline.api
 from zipline.api import FixedSlippage
@@ -472,7 +472,7 @@ def log_nyse_close(context, data):
         erroring_algotext = dedent(
             """
             from zipline.api import schedule_function
-            from trading_calendars import get_calendar
+            from zipline.utils.calendar_utils import get_calendar
 
             def initialize(context):
                 schedule_function(func=my_func, calendar=get_calendar('XNYS'))

--- a/tests/test_bar_data.py
+++ b/tests/test_bar_data.py
@@ -21,8 +21,7 @@ from numpy import nan
 from numpy.testing import assert_almost_equal
 import pandas as pd
 from toolz import concat
-from trading_calendars import get_calendar
-from trading_calendars.utils.pandas_utils import days_at_time
+from zipline.utils.calendar_utils import get_calendar, days_at_time
 
 from zipline._protocol import handle_non_market_minutes
 

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,7 +1,6 @@
 from datetime import time
 import pandas as pd
-from trading_calendars import get_calendar
-from trading_calendars.utils.pandas_utils import days_at_time
+from zipline.utils.calendar_utils import get_calendar, days_at_time
 
 from zipline.gens.sim_engine import (
     MinuteSimulationClock,

--- a/tests/utils/test_date_utils.py
+++ b/tests/utils/test_date_utils.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from trading_calendars import get_calendar
+from zipline.utils.calendar_utils import get_calendar
 from pandas.testing import assert_index_equal
 
 from zipline.utils.date_utils import compute_date_range_chunks, make_utc_aware


### PR DESCRIPTION
- Zipline is now compatible with pandas > 1.2.5 and exchange-calendars
- Backward compatibility with pandas==1.2.5 and trading-calendars is maintained in case
