### PR TITLE
MAINT: Using codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,5 @@
 [run]
 include = */src/*
-source = src/zipline
 [report]
 omit =
     */python?.?/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
+[run]
+source=zipline-reloaded
 [report]
 omit =
     */python?.?/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
-source= src/zipline
+include = */src/*
+source = src/zipline
 [report]
 omit =
     */python?.?/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
-[run]
-include = */src/*
 [report]
 omit =
+    .venv/*
+    */tests/*
     */python?.?/*
 exclude_lines =
     raise NotImplementedError

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source=zipline-reloaded
+source= src/zipline
 [report]
 omit =
     */python?.?/*

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -94,13 +94,13 @@ jobs:
 
       - name: Upload coverage data to Codecov
         uses: codecov/codecov-action@v2
-        # with:
-        #   token: ${{ secrets.CODECOV_TOKEN }}
-        #   directory: ./coverage/reports/
-        #   env_vars: OS,PYTHON
-        #   fail_ci_if_error: true
-        #   files: ./coverage1.xml,./coverage2.xml
-        #   flags: unittests
-        #   name: codecov-umbrella
-        #   path_to_write_report: ./coverage/codecov_report.txt
-        #   verbose: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage/reports/
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          files: ./coverage1.xml,./coverage2.xml
+          flags: unittests
+          name: codecov-umbrella
+          path_to_write_report: ./coverage/codecov_report.txt
+          verbose: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -97,9 +97,9 @@ jobs:
         with:
           # token: ${{ secrets.CODECOV_TOKEN }}
           # directory: ./coverage/reports/
-          env_vars: OS,PYTHON
+          # env_vars: OS,PYTHON
           fail_ci_if_error: true
-          files: ./coverage.xml,
-          flags: unittests
+          # files: ./coverage.xml,
+          # flags: unittests
           name: codecov-umbrella
           verbose: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     branches:
-      - test-codecov
+      - main
   schedule:
     - cron: "0 9 * * 6"
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,10 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ ubuntu-latest, windows-latest, macos-latest ]
-        os: [ ubuntu-latest ]
-        # python-version: [ 3.7, 3.8, 3.9 ]
-        python-version: [ 3.8 ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        python-version: [ 3.7, 3.8, 3.9 ]
         exclude:
           - os: windows-latest
             python-version: 3.9
@@ -95,11 +93,6 @@ jobs:
       - name: Upload coverage data to Codecov
         uses: codecov/codecov-action@v2
         with:
-          # token: ${{ secrets.CODECOV_TOKEN }}
-          # directory: ./coverage/reports/
-          # env_vars: OS,PYTHON
           fail_ci_if_error: true
-          # files: ./coverage.xml,
-          # flags: unittests
           name: codecov-umbrella
           verbose: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -96,11 +96,10 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./coverage/reports/
+          # directory: ./coverage/reports/
           env_vars: OS,PYTHON
           fail_ci_if_error: true
-          files: ./coverage1.xml,./coverage2.xml
+          files: ./coverage.xml,
           flags: unittests
           name: codecov-umbrella
-          path_to_write_report: ./coverage/codecov_report.txt
           verbose: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Upload coverage data to Codecov
         uses: codecov/codecov-action@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # token: ${{ secrets.CODECOV_TOKEN }}
           # directory: ./coverage/reports/
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches:
-      - main
+      - test-codecov
   schedule:
     - cron: "0 9 * * 6"
 
@@ -14,8 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ 3.7, 3.8, 3.9 ]
+        # os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest ]
+        # python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.8 ]
         exclude:
           - os: windows-latest
             python-version: 3.9
@@ -90,7 +92,15 @@ jobs:
         run: |
           tox
 
-      - name: Upload coverage data to coveralls.io
-        run: coveralls --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage data to Codecov
+        uses: codecov/codecov-action@v2
+        # with:
+        #   token: ${{ secrets.CODECOV_TOKEN }}
+        #   directory: ./coverage/reports/
+        #   env_vars: OS,PYTHON
+        #   fail_ci_if_error: true
+        #   files: ./coverage1.xml,./coverage2.xml
+        #   flags: unittests
+        #   name: codecov-umbrella
+        #   path_to_write_report: ./coverage/codecov_report.txt
+        #   verbose: true

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ python =
     # 3.9: py39
 
 [testenv]
+usedevelop=True
 deps =
     pytest
     pytest-cov
@@ -33,7 +34,7 @@ commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
     py38-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
     # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
-    py.test --cov={envsitepackagesdir}/src/zipline --cov-append --cov-report=xml {toxinidir}/tests
+    py.test --cov=src/zipline --cov-append --cov-report=xml {toxinidir}/tests
 
 # [testenv:report]
 # deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -36,13 +36,13 @@ commands =
     # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
     py.test --cov=./ --cov-report=xml {toxinidir}/tests
 
-[testenv:report]
-deps = 
-    codecov
-    coverage
-skip_install = true
-commands =
-    codecov
+# [testenv:report]
+# deps = 
+#     codecov
+#     coverage
+# skip_install = true
+# commands =
+#     codecov
 
 # [testenv:clean]
 # deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
     py38-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
     # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
-    py.test --cov=./ --cov-report=xml {toxinidir}/tests
+    py.test --cov-report term  --cov-report=xml --cov-report=html:htmlcov {toxinidir}/tests
 
 # [testenv:report]
 # deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ python =
 deps =
     pytest
     pytest-cov
+    codecov
+    coverage
 setenv =
     MPLBACKEND = Agg
     COVERAGE_FILE=.coverage.{envname}
@@ -31,16 +33,16 @@ commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
     py38-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
     # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
-    py.test --cov --cov-append --cov-report=xml {toxinidir}/tests
+    py.test --cov={envsitepackagesdir}/src/zipline --cov-append --cov-report=xml {toxinidir}/tests
 
-[testenv:report]
-deps = 
-    codecov
-    coverage
-skip_install = true
-commands =
-    coverage report
-    coverage html
+# [testenv:report]
+# deps = 
+#     codecov
+#     coverage
+# skip_install = true
+# commands =
+#     coverage report
+#     coverage html
 
 # [testenv:clean]
 # deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     coverage
 setenv =
     MPLBACKEND = Agg
-    COVERAGE_FILE=.coverage.{envname}
+    # COVERAGE_FILE=.coverage.{envname}
 
 changedir = tmp
 extras = test
@@ -34,7 +34,7 @@ commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
     py38-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
     # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
-    py.test --cov-report term  --cov-report=xml --cov-report=html:htmlcov {toxinidir}/tests
+    py.test --cov={toxinidir}/src --cov-report term  --cov-report=xml --cov-report=html:htmlcov {toxinidir}/tests
 
 # [testenv:report]
 # deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-# envlist = py{37,38,39}-pandas{11,12,13}
-envlist = py{38}-pandas{12}
+envlist = py{37,38,39}-pandas{11,12,13}
 isolated_build = True
 skip_missing_interpreters = True
 minversion = 3.23.0
@@ -13,9 +12,9 @@ requires = setuptools >=42.0.0
 
 [gh-actions]
 python =
-    # 3.7: py37
+    3.7: py37
     3.8: py38
-    # 3.9: py39
+    3.9: py39
 
 [testenv]
 usedevelop=True
@@ -31,20 +30,7 @@ setenv =
 changedir = tmp
 extras = test
 commands =
-    # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
-    py38-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
-    # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
+    py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
+    py{38,38,39}-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
+    py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
     py.test --cov={toxinidir}/src --cov-report term  --cov-report=xml --cov-report=html:htmlcov {toxinidir}/tests
-
-# [testenv:report]
-# deps = 
-#     codecov
-#     coverage
-# skip_install = true
-# commands =
-#     codecov
-
-# [testenv:clean]
-# deps = coverage
-# skip_install = true
-# commands = coverage erase

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py{37,38,39}-pandas{11,12,13}
+# envlist = py{37,38,39}-pandas{11,12,13}
+envlist = py{38}-pandas{12}
 isolated_build = True
 skip_missing_interpreters = True
 minversion = 3.23.0
@@ -23,8 +24,6 @@ deps =
 setenv =
     MPLBACKEND = Agg
     COVERAGE_FILE=.coverage.{envname}
-    setenv =
-        PYTHONPATH = {toxinidir}
 
 changedir = tmp
 extras = test
@@ -32,7 +31,7 @@ commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
     py38-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
     # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
-    py.test --cov --cov-append --cov-report=xml tests
+    py.test --cov --cov-append --cov-report=xml {toxinidir}/tests
 
 [testenv:report]
 deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ requires = setuptools >=42.0.0
 
 [gh-actions]
 python =
-    3.7: py37
+    # 3.7: py37
     3.8: py38
-    3.9: py39
+    # 3.9: py39
 
 [testenv]
 deps =
@@ -23,23 +23,27 @@ deps =
 setenv =
     MPLBACKEND = Agg
     COVERAGE_FILE=.coverage.{envname}
+    setenv =
+        PYTHONPATH = {toxinidir}
 
 changedir = tmp
 extras = test
 commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
-    py{37,38,39}-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
+    py38-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
     # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
-    py.test --cov --cov-append --cov-report=html {toxinidir}/tests
+    py.test --cov --cov-append --cov-report=xml tests
 
 [testenv:report]
-deps = coverage
+deps = 
+    codecov
+    coverage
 skip_install = true
 commands =
     coverage report
     coverage html
 
-[testenv:clean]
-deps = coverage
-skip_install = true
-commands = coverage erase
+# [testenv:clean]
+# deps = coverage
+# skip_install = true
+# commands = coverage erase

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
     py38-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
     # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
-    py.test --cov=src/zipline --cov-append --cov-report=xml {toxinidir}/tests
+    py.test --cov=./ --cov-report=xml {toxinidir}/tests
 
 # [testenv:report]
 # deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -36,14 +36,13 @@ commands =
     # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
     py.test --cov=./ --cov-report=xml {toxinidir}/tests
 
-# [testenv:report]
-# deps = 
-#     codecov
-#     coverage
-# skip_install = true
-# commands =
-#     coverage report
-#     coverage html
+[testenv:report]
+deps = 
+    codecov
+    coverage
+skip_install = true
+commands =
+    codecov
 
 # [testenv:clean]
 # deps = coverage


### PR DESCRIPTION
Switched to used [codecov ](https://docs.codecov.com/docs) after several failed attempts to use coverall.
Codecov would need to added as an authorized app for the CI tests to complete
