### PR TITLE
upper boundary to pandas

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ install_requires =
     networkx >=2.0
     numexpr >=2.6.1
     numpy >=1.14.5
-    pandas >=1.1.0
+    pandas >=1.1.0<=1.3.5
     patsy >=0.4.0
     python-dateutil >=2.4.2
     python-interface >=1.5.3

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ python =
 deps =
     pytest
     pytest-cov
+    pytest-xdist
 setenv =
     MPLBACKEND = Agg
     COVERAGE_FILE=.coverage.{envname}
@@ -30,7 +31,7 @@ commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
     py{37,38,39}-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
     py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0,<=1.3.5
-    py.test --cov --cov-append --cov-report=html {toxinidir}/tests
+    py.test -n 2 --cov --cov-append --cov-report=html {toxinidir}/tests
 
 [testenv:report]
 deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ extras = test
 commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
     py{37,38,39}-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
-    # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0,<1.3.5
+    py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0,<=1.3.5
     py.test --cov --cov-append --cov-report=html {toxinidir}/tests
 
 [testenv:report]

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ extras = test
 commands =
     # py{37,38,39}-pandas11: pip install -vv pandas>=1.1.0,<1.2.0
     py{37,38,39}-pandas12: pip install -vv pandas>=1.2.0,<1.3.0
-    # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0
+    # py{37,38,39}-pandas13: pip install -vv pandas>=1.3.0,<1.3.5
     py.test --cov --cov-append --cov-report=html {toxinidir}/tests
 
 [testenv:report]


### PR DESCRIPTION
pandas 1.4.0 made several [backward incompatible changes ](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.4.0.html#backwards-incompatible-api-changes). Setting an upper bound to version 1.3.5 should fix the current issues