### PR TITLE
ENH: Allow more than 3 chars for root_symbols

### DIFF
--- a/src/zipline/assets/assets.py
+++ b/src/zipline/assets/assets.py
@@ -241,33 +241,15 @@ CONTINUOUS_FUTURE_ADJUSTMENT_STYLE_IDS = {
 
 
 def _encode_continuous_future_sid(root_symbol, offset, roll_style, adjustment_style):
-    s = struct.Struct("B 2B B B B 2B")
-    # B - sid type
-    # 2B - root symbol
-    # B - offset (could be packed smaller since offsets of greater than 12 are
-    #             probably unneeded.)
-    # B - roll type
-    # B - adjustment
-    # 2B - empty space left for parameterized roll types
-
-    # The root symbol currently supports 2 characters.  If 3 char root symbols
-    # are needed, the size of the root symbol does not need to change, however
-    # writing the string directly will need to change to a scheme of writing
-    # the A-Z values in 5-bit chunks.
-    a = array.array("B", [0] * s.size)
-    rs = bytearray(root_symbol, "ascii")
+    # Generate a unique int identifier
     values = (
         SID_TYPE_IDS[ContinuousFuture],
-        rs[0],
-        rs[1],
         offset,
+        *[ord(x) for x in root_symbol.upper()],
         CONTINUOUS_FUTURE_ROLL_STYLE_IDS[roll_style],
         CONTINUOUS_FUTURE_ADJUSTMENT_STYLE_IDS[adjustment_style],
-        0,
-        0,
     )
-    s.pack_into(a, 0, *values)
-    return int(binascii.hexlify(a), 16)
+    return int("".join([str(x) for x in values]))
 
 
 Lifetimes = namedtuple("Lifetimes", "sid start end")

--- a/tests/test_continuous_futures.py
+++ b/tests/test_continuous_futures.py
@@ -51,7 +51,7 @@ class ContinuousFuturesTestCase(
     def make_root_symbols_info(self):
         return pd.DataFrame(
             {
-                "root_symbol": ["FO", "BZ", "MA", "DF"],
+                "root_symbol": ["FOOBAR", "BZ", "MA", "DF"],
                 "root_symbol_id": [1, 2, 3, 4],
                 "exchange": ["CMES", "CMES", "CMES", "CMES"],
             }
@@ -62,16 +62,16 @@ class ContinuousFuturesTestCase(
         fo_frame = pd.DataFrame(
             {
                 "symbol": [
-                    "FOF16",
-                    "FOG16",
-                    "FOH16",
-                    "FOJ16",
-                    "FOK16",
-                    "FOF22",
-                    "FOG22",
+                    "FOOBARF16",
+                    "FOOBARG16",
+                    "FOOBARH16",
+                    "FOOBARJ16",
+                    "FOOBARK16",
+                    "FOOBARF22",
+                    "FOOBARG22",
                 ],
                 "sid": range(0, 7),
-                "root_symbol": ["FO"] * 7,
+                "root_symbol": ["FOOBAR"] * 7,
                 "asset_name": ["Foo"] * 7,
                 "start_date": [
                     pd.Timestamp("2015-01-05", tz="UTC"),
@@ -296,11 +296,11 @@ class ContinuousFuturesTestCase(
         # place can be used to eyeball the source contract.
 
         # For volume roll tests end sid volume early.
-        # FOF16 cuts out day before autoclose of 01-26
-        # FOG16 cuts out on autoclose
-        # FOH16 cuts out 4 days before autoclose
-        # FOJ16 cuts out 3 days before autoclose
-        # Make FOG22 have a blip of trading, but not be the actively trading,
+        # FOOBARF16 cuts out day before autoclose of 01-26
+        # FOOBARG16 cuts out on autoclose
+        # FOOBARH16 cuts out 4 days before autoclose
+        # FOOBARJ16 cuts out 3 days before autoclose
+        # Make FOOBARG22 have a blip of trading, but not be the actively trading,
         # so that it does not particpate in volume rolls.
 
         sid_to_vol_stop_session = {
@@ -418,10 +418,10 @@ class ContinuousFuturesTestCase(
 
     def test_create_continuous_future(self):
         cf_primary = self.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
 
-        assert cf_primary.root_symbol == "FO"
+        assert cf_primary.root_symbol == "FOOBAR"
         assert cf_primary.offset == 0
         assert cf_primary.roll_style == "calendar"
         assert cf_primary.start_date == pd.Timestamp("2015-01-05", tz="UTC")
@@ -432,10 +432,10 @@ class ContinuousFuturesTestCase(
         assert retrieved_primary == cf_primary
 
         cf_secondary = self.asset_finder.create_continuous_future(
-            "FO", 1, "calendar", None
+            "FOOBAR", 1, "calendar", None
         )
 
-        assert cf_secondary.root_symbol == "FO"
+        assert cf_secondary.root_symbol == "FOOBAR"
         assert cf_secondary.offset == 1
         assert cf_secondary.roll_style == "calendar"
         assert cf_primary.start_date == pd.Timestamp("2015-01-05", tz="UTC")
@@ -454,24 +454,24 @@ class ContinuousFuturesTestCase(
 
     def test_current_contract(self):
         cf_primary = self.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
         bar_data = self.create_bardata(lambda: pd.Timestamp("2016-01-26", tz="UTC"))
         contract = bar_data.current(cf_primary, "contract")
 
-        assert contract.symbol == "FOF16"
+        assert contract.symbol == "FOOBARF16"
 
         bar_data = self.create_bardata(lambda: pd.Timestamp("2016-01-27", tz="UTC"))
         contract = bar_data.current(cf_primary, "contract")
 
-        assert contract.symbol == "FOG16", (
-            "Auto close at beginning of session so FOG16 is now "
+        assert contract.symbol == "FOOBARG16", (
+            "Auto close at beginning of session so FOOBARG16 is now "
             "the current contract."
         )
 
     def test_get_value_contract_daily(self):
         cf_primary = self.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
 
         contract = self.data_portal.get_spot_value(
@@ -481,7 +481,7 @@ class ContinuousFuturesTestCase(
             "daily",
         )
 
-        assert contract.symbol == "FOF16"
+        assert contract.symbol == "FOOBARF16"
 
         contract = self.data_portal.get_spot_value(
             cf_primary,
@@ -490,8 +490,8 @@ class ContinuousFuturesTestCase(
             "daily",
         )
 
-        assert contract.symbol == "FOG16", (
-            "Auto close at beginning of session so FOG16 is now "
+        assert contract.symbol == "FOOBARG16", (
+            "Auto close at beginning of session so FOOBARG16 is now "
             "the current contract."
         )
 
@@ -507,7 +507,7 @@ class ContinuousFuturesTestCase(
 
     def test_get_value_close_daily(self):
         cf_primary = self.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
 
         value = self.data_portal.get_spot_value(
@@ -527,7 +527,7 @@ class ContinuousFuturesTestCase(
         )
 
         assert value == 115021.44, (
-            "Auto close at beginning of session so FOG16 is now "
+            "Auto close at beginning of session so FOOBARG16 is now "
             "the current contract."
         )
 
@@ -542,29 +542,32 @@ class ContinuousFuturesTestCase(
         )
 
         assert value == 135441.44, (
-            "Value should be for FOJ16, even though last "
+            "Value should be for FOOBARJ16, even though last "
             "contract ends before query date."
         )
 
     def test_current_contract_volume_roll(self):
-        cf_primary = self.asset_finder.create_continuous_future("FO", 0, "volume", None)
+        cf_primary = self.asset_finder.create_continuous_future(
+            "FOOBAR", 0, "volume", None
+        )
         bar_data = self.create_bardata(lambda: pd.Timestamp("2016-01-26", tz="UTC"))
         contract = bar_data.current(cf_primary, "contract")
 
-        assert contract.symbol == "FOF16"
+        assert contract.symbol == "FOOBARF16"
 
         bar_data = self.create_bardata(lambda: pd.Timestamp("2016-01-27", tz="UTC"))
         contract = bar_data.current(cf_primary, "contract")
 
-        assert contract.symbol == "FOG16", (
-            "Auto close at beginning of session. FOG16 is now " "the current contract."
+        assert contract.symbol == "FOOBARG16", (
+            "Auto close at beginning of session. FOOBARG16 is now "
+            "the current contract."
         )
 
         bar_data = self.create_bardata(lambda: pd.Timestamp("2016-02-29", tz="UTC"))
         contract = bar_data.current(cf_primary, "contract")
         assert (
-            contract.symbol == "FOH16"
-        ), "Volume switch to FOH16, should have triggered roll."
+            contract.symbol == "FOOBARH16"
+        ), "Volume switch to FOOBARH16, should have triggered roll."
 
     def test_current_contract_in_algo(self):
         code = dedent(
@@ -577,8 +580,8 @@ from zipline.api import (
 )
 
 def initialize(algo):
-    algo.primary_cl = continuous_future('FO', 0, 'calendar', None)
-    algo.secondary_cl = continuous_future('FO', 1, 'calendar', None)
+    algo.primary_cl = continuous_future('FOOBAR', 0, 'calendar', None)
+    algo.secondary_cl = continuous_future('FOOBAR', 1, 'calendar', None)
     schedule_function(record_current_contract)
 
 def record_current_contract(algo, data):
@@ -591,31 +594,31 @@ def record_current_contract(algo, data):
         result = results.iloc[0]
 
         assert (
-            result.primary.symbol == "FOF16"
-        ), "Primary should be FOF16 on first session."
+            result.primary.symbol == "FOOBARF16"
+        ), "Primary should be FOOBARF16 on first session."
         assert (
-            result.secondary.symbol == "FOG16"
-        ), "Secondary should be FOG16 on first session."
+            result.secondary.symbol == "FOOBARG16"
+        ), "Secondary should be FOOBARG16 on first session."
 
         result = results.iloc[1]
-        # Second day, primary should switch to FOG
-        assert result.primary.symbol == "FOG16", (
-            "Primary should be FOG16 on second session, auto "
+        # Second day, primary should switch to FOOBARG
+        assert result.primary.symbol == "FOOBARG16", (
+            "Primary should be FOOBARG16 on second session, auto "
             "close is at beginning of the session."
         )
-        assert result.secondary.symbol == "FOH16", (
-            "Secondary should be FOH16 on second session, auto "
+        assert result.secondary.symbol == "FOOBARH16", (
+            "Secondary should be FOOBARH16 on second session, auto "
             "close is at beginning of the session."
         )
 
         result = results.iloc[2]
-        # Second day, primary should switch to FOG
+        # Second day, primary should switch to FOOBARG
         assert (
-            result.primary.symbol == "FOG16"
-        ), "Primary should remain as FOG16 on third session."
+            result.primary.symbol == "FOOBARG16"
+        ), "Primary should remain as FOOBARG16 on third session."
         assert (
-            result.secondary.symbol == "FOH16"
-        ), "Secondary should remain as FOH16 on third session."
+            result.secondary.symbol == "FOOBARH16"
+        ), "Secondary should remain as FOOBARH16 on third session."
 
     def test_current_chain_in_algo(self):
         code = dedent(
@@ -628,8 +631,8 @@ from zipline.api import (
 )
 
 def initialize(algo):
-    algo.primary_cl = continuous_future('FO', 0, 'calendar', None)
-    algo.secondary_cl = continuous_future('FO', 1, 'calendar', None)
+    algo.primary_cl = continuous_future('FOOBAR', 0, 'calendar', None)
+    algo.secondary_cl = continuous_future('FOOBAR', 1, 'calendar', None)
     schedule_function(record_current_contract)
 
 def record_current_contract(algo, data):
@@ -661,21 +664,21 @@ def record_current_contract(algo, data):
             "the primary on that date."
         )
 
-        assert result.primary_first == "FOF16", (
-            "Front of primary chain should be FOF16 on first " "session."
+        assert result.primary_first == "FOOBARF16", (
+            "Front of primary chain should be FOOBARF16 on first " "session."
         )
-        assert result.secondary_first == "FOG16", (
-            "Front of secondary chain should be FOG16 on first " "session."
-        )
-
-        assert result.primary_last == "FOG22", (
-            "End of primary chain should be FOK16 on first " "session."
-        )
-        assert result.secondary_last == "FOG22", (
-            "End of secondary chain should be FOK16 on first " "session."
+        assert result.secondary_first == "FOOBARG16", (
+            "Front of secondary chain should be FOOBARG16 on first " "session."
         )
 
-        # Second day, primary should switch to FOG
+        assert result.primary_last == "FOOBARG22", (
+            "End of primary chain should be FOOBARK16 on first " "session."
+        )
+        assert result.secondary_last == "FOOBARG22", (
+            "End of secondary chain should be FOOBARK16 on first " "session."
+        )
+
+        # Second day, primary should switch to FOOBARG
         result = results.iloc[1]
 
         assert result.primary_len == 5, (
@@ -692,25 +695,25 @@ def record_current_contract(algo, data):
             "the second is the primary on that date."
         )
 
-        assert result.primary_first == "FOG16", (
-            "Front of primary chain should be FOG16 on second " "session."
+        assert result.primary_first == "FOOBARG16", (
+            "Front of primary chain should be FOOBARG16 on second " "session."
         )
-        assert result.secondary_first == "FOH16", (
-            "Front of secondary chain should be FOH16 on second " "session."
+        assert result.secondary_first == "FOOBARH16", (
+            "Front of secondary chain should be FOOBARH16 on second " "session."
         )
 
-        # These values remain FOJ16 because fixture data is not exhaustive
+        # These values remain FOOBARJ16 because fixture data is not exhaustive
         # enough to move the end of the chain.
-        assert result.primary_last == "FOG22", (
-            "End of primary chain should be FOK16 on second " "session."
+        assert result.primary_last == "FOOBARG22", (
+            "End of primary chain should be FOOBARK16 on second " "session."
         )
-        assert result.secondary_last == "FOG22", (
-            "End of secondary chain should be FOK16 on second " "session."
+        assert result.secondary_last == "FOOBARG22", (
+            "End of secondary chain should be FOOBARK16 on second " "session."
         )
 
     def test_history_sid_session(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
         window = self.data_portal.get_history_window(
             [cf],
@@ -723,21 +726,23 @@ def record_current_contract(algo, data):
 
         assert (
             window.loc["2016-01-26", cf] == 0
-        ), "Should be FOF16 at beginning of window."
+        ), "Should be FOOBARF16 at beginning of window."
 
-        assert window.loc["2016-01-27", cf] == 1, "Should be FOG16 after first roll."
+        assert (
+            window.loc["2016-01-27", cf] == 1
+        ), "Should be FOOBARG16 after first roll."
 
         assert (
             window.loc["2016-02-25", cf] == 1
-        ), "Should be FOG16 on session before roll."
+        ), "Should be FOOBARG16 on session before roll."
 
         assert (
             window.loc["2016-02-26", cf] == 2
-        ), "Should be FOH16 on session with roll."
+        ), "Should be FOOBARH16 on session with roll."
 
         assert (
             window.loc["2016-02-29", cf] == 2
-        ), "Should be FOH16 on session after roll."
+        ), "Should be FOOBARH16 on session after roll."
 
         # Advance the window a month.
         window = self.data_portal.get_history_window(
@@ -751,23 +756,23 @@ def record_current_contract(algo, data):
 
         assert (
             window.loc["2016-02-25", cf] == 1
-        ), "Should be FOG16 at beginning of window."
+        ), "Should be FOOBARG16 at beginning of window."
 
         assert (
             window.loc["2016-02-26", cf] == 2
-        ), "Should be FOH16 on session with roll."
+        ), "Should be FOOBARH16 on session with roll."
 
         assert (
             window.loc["2016-02-29", cf] == 2
-        ), "Should be FOH16 on session after roll."
+        ), "Should be FOOBARH16 on session after roll."
 
         assert (
             window.loc["2016-03-24", cf] == 3
-        ), "Should be FOJ16 on session with roll."
+        ), "Should be FOOBARJ16 on session with roll."
 
         assert (
             window.loc["2016-03-28", cf] == 3
-        ), "Should be FOJ16 on session after roll."
+        ), "Should be FOOBARJ16 on session after roll."
 
     def test_history_sid_session_delivery_predicate(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
@@ -794,7 +799,7 @@ def record_current_contract(algo, data):
 
     def test_history_sid_session_secondary(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 1, "calendar", None
+            "FOOBAR", 1, "calendar", None
         )
         window = self.data_portal.get_history_window(
             [cf],
@@ -807,21 +812,23 @@ def record_current_contract(algo, data):
 
         assert (
             window.loc["2016-01-26", cf] == 1
-        ), "Should be FOG16 at beginning of window."
+        ), "Should be FOOBARG16 at beginning of window."
 
-        assert window.loc["2016-01-27", cf] == 2, "Should be FOH16 after first roll."
+        assert (
+            window.loc["2016-01-27", cf] == 2
+        ), "Should be FOOBARH16 after first roll."
 
         assert (
             window.loc["2016-02-25", cf] == 2
-        ), "Should be FOH16 on session before roll."
+        ), "Should be FOOBARH16 on session before roll."
 
         assert (
             window.loc["2016-02-26", cf] == 3
-        ), "Should be FOJ16 on session with roll."
+        ), "Should be FOOBARJ16 on session with roll."
 
         assert (
             window.loc["2016-02-29", cf] == 3
-        ), "Should be FOJ16 on session after roll."
+        ), "Should be FOOBARJ16 on session after roll."
 
         # Advance the window a month.
         window = self.data_portal.get_history_window(
@@ -835,27 +842,27 @@ def record_current_contract(algo, data):
 
         assert (
             window.loc["2016-02-25", cf] == 2
-        ), "Should be FOH16 at beginning of window."
+        ), "Should be FOOBARH16 at beginning of window."
 
         assert (
             window.loc["2016-02-26", cf] == 3
-        ), "Should be FOJ16 on session with roll."
+        ), "Should be FOOBARJ16 on session with roll."
 
         assert (
             window.loc["2016-02-29", cf] == 3
-        ), "Should be FOJ16 on session after roll."
+        ), "Should be FOOBARJ16 on session after roll."
 
         assert (
             window.loc["2016-03-24", cf] == 4
-        ), "Should be FOK16 on session with roll."
+        ), "Should be FOOBARK16 on session with roll."
 
         assert (
             window.loc["2016-03-28", cf] == 4
-        ), "Should be FOK16 on session after roll."
+        ), "Should be FOOBARK16 on session after roll."
 
     def test_history_sid_session_volume_roll(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "volume", None
+            "FOOBAR", 0, "volume", None
         )
         window = self.data_portal.get_history_window(
             [cf],
@@ -866,24 +873,24 @@ def record_current_contract(algo, data):
             "minute",
         )
 
-        # Volume cuts out for FOF16 on 2016-01-25
+        # Volume cuts out for FOOBARF16 on 2016-01-25
         assert (
             window.loc["2016-01-26", cf] == 0
-        ), "Should be FOF16 at beginning of window."
+        ), "Should be FOOBARF16 at beginning of window."
 
-        assert window.loc["2016-01-27", cf] == 1, "Should have rolled to FOG16."
+        assert window.loc["2016-01-27", cf] == 1, "Should have rolled to FOOBARG16."
 
         assert (
             window.loc["2016-02-26", cf] == 1
-        ), "Should be FOG16 on session before roll."
+        ), "Should be FOOBARG16 on session before roll."
 
         assert (
             window.loc["2016-02-29", cf] == 2
-        ), "Should be FOH16 on session with roll."
+        ), "Should be FOOBARH16 on session with roll."
 
         assert (
             window.loc["2016-03-01", cf] == 2
-        ), "Should be FOH16 on session after roll."
+        ), "Should be FOOBARH16 on session after roll."
 
         # Advance the window a month.
         window = self.data_portal.get_history_window(
@@ -897,28 +904,28 @@ def record_current_contract(algo, data):
 
         assert (
             window.loc["2016-02-26", cf] == 1
-        ), "Should be FOG16 at beginning of window."
+        ), "Should be FOOBARG16 at beginning of window."
 
-        assert window.loc["2016-02-29", cf] == 2, "Should be FOH16 on roll session."
+        assert window.loc["2016-02-29", cf] == 2, "Should be FOOBARH16 on roll session."
 
-        assert window.loc["2016-03-01", cf] == 2, "Should remain FOH16."
+        assert window.loc["2016-03-01", cf] == 2, "Should remain FOOBARH16."
 
         assert (
             window.loc["2016-03-17", cf] == 2
-        ), "Should be FOH16 on session before volume cuts out."
+        ), "Should be FOOBARH16 on session before volume cuts out."
 
         assert window.loc["2016-03-18", cf] == 2, (
-            "Should be FOH16 on session where the volume of "
-            "FOH16 cuts out, the roll is upcoming."
+            "Should be FOOBARH16 on session where the volume of "
+            "FOOBARH16 cuts out, the roll is upcoming."
         )
 
-        assert window.loc["2016-03-24", cf] == 3, "Should have rolled to FOJ16."
+        assert window.loc["2016-03-24", cf] == 3, "Should have rolled to FOOBARJ16."
 
-        assert window.loc["2016-03-28", cf] == 3, "Should have remained FOJ16."
+        assert window.loc["2016-03-28", cf] == 3, "Should have remained FOOBARJ16."
 
     def test_history_sid_minute(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
         window = self.data_portal.get_history_window(
             [cf.sid],
@@ -930,17 +937,17 @@ def record_current_contract(algo, data):
         )
 
         assert window.loc[pd.Timestamp("2016-01-26 22:32", tz="UTC"), cf.sid] == 0, (
-            "Should be FOF16 at beginning of window. A minute "
+            "Should be FOOBARF16 at beginning of window. A minute "
             "which is in the 01-26 session, before the roll."
         )
 
         assert (
             window.loc[pd.Timestamp("2016-01-26 23:00", tz="UTC"), cf.sid] == 0
-        ), "Should be FOF16 on on minute before roll minute."
+        ), "Should be FOOBARF16 on on minute before roll minute."
 
         assert (
             window.loc[pd.Timestamp("2016-01-26 23:01", tz="UTC"), cf.sid] == 1
-        ), "Should be FOG16 on minute after roll."
+        ), "Should be FOOBARG16 on minute after roll."
 
         # Advance the window a day.
         window = self.data_portal.get_history_window(
@@ -954,15 +961,15 @@ def record_current_contract(algo, data):
 
         assert (
             window.loc[pd.Timestamp("2016-01-27 22:32", tz="UTC"), cf.sid] == 1
-        ), "Should be FOG16 at beginning of window."
+        ), "Should be FOOBARG16 at beginning of window."
 
         assert (
             window.loc[pd.Timestamp("2016-01-27 23:01", tz="UTC"), cf.sid] == 1
-        ), "Should remain FOG16 on next session."
+        ), "Should remain FOOBARG16 on next session."
 
     def test_history_close_session(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
         window = self.data_portal.get_history_window(
             [cf.sid], pd.Timestamp("2016-03-06", tz="UTC"), 30, "1d", "close", "daily"
@@ -971,19 +978,19 @@ def record_current_contract(algo, data):
         assert_almost_equal(
             window.loc[pd.Timestamp("2016-01-26", tz="UTC"), cf.sid],
             105011.440,
-            err_msg="At beginning of window, should be FOG16's first value.",
+            err_msg="At beginning of window, should be FOOBARG16's first value.",
         )
 
         assert_almost_equal(
             window.loc[pd.Timestamp("2016-02-26", tz="UTC"), cf.sid],
             125241.440,
-            err_msg="On session with roll, should be FOH16's 24th value.",
+            err_msg="On session with roll, should be FOOBARH16's 24th value.",
         )
 
         assert_almost_equal(
             window.loc[pd.Timestamp("2016-02-29", tz="UTC"), cf.sid],
             125251.440,
-            err_msg="After roll, Should be FOH16's 25th value.",
+            err_msg="After roll, Should be FOOBARH16's 25th value.",
         )
 
         # Advance the window a month.
@@ -994,31 +1001,31 @@ def record_current_contract(algo, data):
         assert_almost_equal(
             window.loc[pd.Timestamp("2016-02-24", tz="UTC"), cf.sid],
             115221.440,
-            err_msg="At beginning of window, should be FOG16's 22nd value.",
+            err_msg="At beginning of window, should be FOOBARG16's 22nd value.",
         )
 
         assert_almost_equal(
             window.loc[pd.Timestamp("2016-02-26", tz="UTC"), cf.sid],
             125241.440,
-            err_msg="On session with roll, should be FOH16's 24th value.",
+            err_msg="On session with roll, should be FOOBARH16's 24th value.",
         )
 
         assert_almost_equal(
             window.loc[pd.Timestamp("2016-02-29", tz="UTC"), cf.sid],
             125251.440,
-            err_msg="On session after roll, should be FOH16's 25th value.",
+            err_msg="On session after roll, should be FOOBARH16's 25th value.",
         )
 
         assert_almost_equal(
             window.loc[pd.Timestamp("2016-03-24", tz="UTC"), cf.sid],
             135431.440,
-            err_msg="On session with roll, should be FOJ16's 43rd value.",
+            err_msg="On session with roll, should be FOOBARJ16's 43rd value.",
         )
 
         assert_almost_equal(
             window.loc[pd.Timestamp("2016-03-28", tz="UTC"), cf.sid],
             135441.440,
-            err_msg="On session after roll, Should be FOJ16's 44th value.",
+            err_msg="On session after roll, Should be FOOBARJ16's 44th value.",
         )
 
     def test_history_close_session_skip_volume(self):
@@ -1072,13 +1079,13 @@ def record_current_contract(algo, data):
 
     def test_history_close_session_adjusted(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
         cf_mul = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", "mul"
+            "FOOBAR", 0, "calendar", "mul"
         )
         cf_add = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", "add"
+            "FOOBAR", 0, "calendar", "add"
         )
         window = self.data_portal.get_history_window(
             [cf, cf_mul, cf_add],
@@ -1095,7 +1102,7 @@ def record_current_contract(algo, data):
         assert_almost_equal(
             window.loc["2016-01-26", cf_mul],
             124992.348,
-            err_msg="At beginning of window, should be FOG16's first value, "
+            err_msg="At beginning of window, should be FOOBARG16's first value, "
             "adjusted.",
         )
 
@@ -1103,34 +1110,34 @@ def record_current_contract(algo, data):
         assert_almost_equal(
             window.loc["2016-01-26", cf_add],
             125011.44,
-            err_msg="At beginning of window, should be FOG16's first value, "
+            err_msg="At beginning of window, should be FOOBARG16's first value, "
             "adjusted.",
         )
 
         assert_almost_equal(
             window.loc["2016-02-26", cf_mul],
             125241.440,
-            err_msg="On session with roll, should be FOH16's 24th value, "
+            err_msg="On session with roll, should be FOOBARH16's 24th value, "
             "unadjusted.",
         )
 
         assert_almost_equal(
             window.loc["2016-02-26", cf_add],
             125241.440,
-            err_msg="On session with roll, should be FOH16's 24th value, "
+            err_msg="On session with roll, should be FOOBARH16's 24th value, "
             "unadjusted.",
         )
 
         assert_almost_equal(
             window.loc["2016-02-29", cf_mul],
             125251.440,
-            err_msg="After roll, Should be FOH16's 25th value, unadjusted.",
+            err_msg="After roll, Should be FOOBARH16's 25th value, unadjusted.",
         )
 
         assert_almost_equal(
             window.loc["2016-02-29", cf_add],
             125251.440,
-            err_msg="After roll, Should be FOH16's 25th value, unadjusted.",
+            err_msg="After roll, Should be FOOBARH16's 25th value, unadjusted.",
         )
 
         # Advance the window a month.
@@ -1159,14 +1166,14 @@ def record_current_contract(algo, data):
         assert_almost_equal(
             window.loc["2016-02-24", cf_mul],
             135236.905,
-            err_msg="At beginning of window, should be FOG16's 22nd value, "
+            err_msg="At beginning of window, should be FOOBARG16's 22nd value, "
             "with two adjustments.",
         )
 
         assert_almost_equal(
             window.loc["2016-02-24", cf_add],
             135251.44,
-            err_msg="At beginning of window, should be FOG16's 22nd value, "
+            err_msg="At beginning of window, should be FOOBARG16's 22nd value, "
             "with two adjustments",
         )
 
@@ -1174,14 +1181,14 @@ def record_current_contract(algo, data):
         assert_almost_equal(
             window.loc["2016-02-26", cf_mul],
             135259.442,
-            err_msg="On session with roll, should be FOH16's 24th value, "
+            err_msg="On session with roll, should be FOOBARH16's 24th value, "
             "with one adjustment.",
         )
 
         assert_almost_equal(
             window.loc["2016-02-26", cf_add],
             135271.44,
-            err_msg="On session with roll, should be FOH16's 24th value, "
+            err_msg="On session with roll, should be FOOBARH16's 24th value, "
             "with one adjustment.",
         )
 
@@ -1189,14 +1196,14 @@ def record_current_contract(algo, data):
         assert_almost_equal(
             window.loc["2016-02-29", cf_mul],
             135270.241,
-            err_msg="On session after roll, should be FOH16's 25th value, "
+            err_msg="On session after roll, should be FOOBARH16's 25th value, "
             "with one adjustment.",
         )
 
         assert_almost_equal(
             window.loc["2016-02-29", cf_add],
             135281.44,
-            err_msg="On session after roll, should be FOH16's 25th value, "
+            err_msg="On session after roll, should be FOOBARH16's 25th value, "
             "unadjusted.",
         )
 
@@ -1204,32 +1211,32 @@ def record_current_contract(algo, data):
         assert_almost_equal(
             window.loc["2016-03-24", cf_mul],
             135431.44,
-            err_msg="On session with roll, should be FOJ16's 43rd value, "
+            err_msg="On session with roll, should be FOOBARJ16's 43rd value, "
             "unadjusted.",
         )
 
         assert_almost_equal(
             window.loc["2016-03-24", cf_add],
             135431.44,
-            err_msg="On session with roll, should be FOJ16's 43rd value.",
+            err_msg="On session with roll, should be FOOBARJ16's 43rd value.",
         )
 
         # Unadjusted: 135441.44
         assert_almost_equal(
             window.loc["2016-03-28", cf_mul],
             135441.44,
-            err_msg="On session after roll, Should be FOJ16's 44th value.",
+            err_msg="On session after roll, Should be FOOBARJ16's 44th value.",
         )
 
         assert_almost_equal(
             window.loc["2016-03-28", cf_add],
             135441.44,
-            err_msg="On session after roll, Should be FOJ16's 44th value.",
+            err_msg="On session after roll, Should be FOOBARJ16's 44th value.",
         )
 
     def test_history_close_minute(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
         window = self.data_portal.get_history_window(
             [cf.sid],
@@ -1243,17 +1250,17 @@ def record_current_contract(algo, data):
         assert (
             window.loc[pd.Timestamp("2016-02-25 22:32", tz="UTC"), cf.sid] == 115231.412
         ), (
-            "Should be FOG16 at beginning of window. A minute "
+            "Should be FOOBARG16 at beginning of window. A minute "
             "which is in the 02-25 session, before the roll."
         )
 
         assert (
             window.loc[pd.Timestamp("2016-02-25 23:00", tz="UTC"), cf.sid] == 115231.440
-        ), "Should be FOG16 on on minute before roll minute."
+        ), "Should be FOOBARG16 on on minute before roll minute."
 
         assert (
             window.loc[pd.Timestamp("2016-02-25 23:01", tz="UTC"), cf.sid] == 125240.001
-        ), "Should be FOH16 on minute after roll."
+        ), "Should be FOOBARH16 on minute after roll."
 
         # Advance the window a session.
         window = self.data_portal.get_history_window(
@@ -1267,21 +1274,21 @@ def record_current_contract(algo, data):
 
         assert (
             window.loc["2016-02-26 22:32", cf] == 125241.412
-        ), "Should be FOH16 at beginning of window."
+        ), "Should be FOOBARH16 at beginning of window."
 
         assert (
             window.loc["2016-02-28 23:01", cf] == 125250.001
-        ), "Should remain FOH16 on next session."
+        ), "Should remain FOOBARH16 on next session."
 
     def test_history_close_minute_adjusted(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", None
+            "FOOBAR", 0, "calendar", None
         )
         cf_mul = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", "mul"
+            "FOOBAR", 0, "calendar", "mul"
         )
         cf_add = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "calendar", "add"
+            "FOOBAR", 0, "calendar", "add"
         )
         window = self.data_portal.get_history_window(
             [cf, cf_mul, cf_add],
@@ -1300,32 +1307,32 @@ def record_current_contract(algo, data):
         # Ratio: ~0.920
         # Difference: 10000.00
         assert window.loc["2016-02-25 22:32", cf_mul] == 125231.41, (
-            "Should be FOG16 at beginning of window. A minute "
+            "Should be FOOBARG16 at beginning of window. A minute "
             "which is in the 02-25 session, before the roll."
         )
 
         assert window.loc["2016-02-25 22:32", cf_add] == 125231.412, (
-            "Should be FOG16 at beginning of window. A minute "
+            "Should be FOOBARG16 at beginning of window. A minute "
             "which is in the 02-25 session, before the roll."
         )
 
         # Unadjusted: 115231.44
         # Should use same ratios as above.
         assert window.loc["2016-02-25 23:00", cf_mul] == 125231.44, (
-            "Should be FOG16 on on minute before roll minute, " "adjusted."
+            "Should be FOOBARG16 on on minute before roll minute, " "adjusted."
         )
 
         assert window.loc["2016-02-25 23:00", cf_add] == 125231.44, (
-            "Should be FOG16 on on minute before roll minute, " "adjusted."
+            "Should be FOOBARG16 on on minute before roll minute, " "adjusted."
         )
 
         assert (
             window.loc["2016-02-25 23:01", cf_mul] == 125240.001
-        ), "Should be FOH16 on minute after roll, unadjusted."
+        ), "Should be FOOBARH16 on minute after roll, unadjusted."
 
         assert (
             window.loc["2016-02-25 23:01", cf_add] == 125240.001
-        ), "Should be FOH16 on minute after roll, unadjusted."
+        ), "Should be FOOBARH16 on minute after roll, unadjusted."
 
         # Advance the window a session.
         window = self.data_portal.get_history_window(
@@ -1340,21 +1347,21 @@ def record_current_contract(algo, data):
         # No adjustments in this window.
         assert (
             window.loc["2016-02-26 22:32", cf_mul] == 125241.412
-        ), "Should be FOH16 at beginning of window."
+        ), "Should be FOOBARH16 at beginning of window."
 
         assert (
             window.loc["2016-02-28 23:01", cf_mul] == 125250.001
-        ), "Should remain FOH16 on next session."
+        ), "Should remain FOOBARH16 on next session."
 
     def test_history_close_minute_adjusted_volume_roll(self):
         cf = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "volume", None
+            "FOOBAR", 0, "volume", None
         )
         cf_mul = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "volume", "mul"
+            "FOOBAR", 0, "volume", "mul"
         )
         cf_add = self.data_portal.asset_finder.create_continuous_future(
-            "FO", 0, "volume", "add"
+            "FOOBAR", 0, "volume", "add"
         )
         window = self.data_portal.get_history_window(
             [cf, cf_mul, cf_add],
@@ -1373,32 +1380,32 @@ def record_current_contract(algo, data):
         # Ratio: ~0.920
         # Difference: 10000.00
         assert window.loc["2016-02-26 22:32", cf_mul] == 125242.973, (
-            "Should be FOG16 at beginning of window. A minute "
+            "Should be FOOBARG16 at beginning of window. A minute "
             "which is in the 02-25 session, before the roll."
         )
 
         assert window.loc["2016-02-26 22:32", cf_add] == 125242.851, (
-            "Should be FOG16 at beginning of window. A minute "
+            "Should be FOOBARG16 at beginning of window. A minute "
             "which is in the 02-25 session, before the roll."
         )
 
         # Unadjusted: 115231.44
         # Should use same ratios as above.
         assert window.loc["2016-02-26 23:00", cf_mul] == 125243.004, (
-            "Should be FOG16 on minute before roll minute, " "adjusted."
+            "Should be FOOBARG16 on minute before roll minute, " "adjusted."
         )
 
         assert window.loc["2016-02-26 23:00", cf_add] == 125242.879, (
-            "Should be FOG16 on minute before roll minute, " "adjusted."
+            "Should be FOOBARG16 on minute before roll minute, " "adjusted."
         )
 
         assert (
             window.loc["2016-02-28 23:01", cf_mul] == 125250.001
-        ), "Should be FOH16 on minute after roll, unadjusted."
+        ), "Should be FOOBARH16 on minute after roll, unadjusted."
 
         assert (
             window.loc["2016-02-28 23:01", cf_add] == 125250.001
-        ), "Should be FOH16 on minute after roll, unadjusted."
+        ), "Should be FOOBARH16 on minute after roll, unadjusted."
 
         # Advance the window a session.
         window = self.data_portal.get_history_window(
@@ -1413,11 +1420,11 @@ def record_current_contract(algo, data):
         # No adjustments in this window.
         assert (
             window.loc["2016-02-29 22:32", cf_mul] == 125251.412
-        ), "Should be FOH16 at beginning of window."
+        ), "Should be FOOBARH16 at beginning of window."
 
         assert (
             window.loc["2016-02-29 23:01", cf_mul] == 125260.001
-        ), "Should remain FOH16 on next session."
+        ), "Should remain FOOBARH16 on next session."
 
 
 class RollFinderTestCase(zf.WithBcolzFutureDailyBarReader, zf.ZiplineTestCase):
@@ -1763,7 +1770,7 @@ class OrderedContractsTestCase(zf.WithAssetFinder, zf.ZiplineTestCase):
     def make_root_symbols_info(self):
         return pd.DataFrame(
             {
-                "root_symbol": ["FO", "BA", "BZ"],
+                "root_symbol": ["FOOBAR", "BA", "BZ"],
                 "root_symbol_id": [1, 2, 3],
                 "exchange": ["CMES", "CMES", "CMES"],
             }
@@ -1773,9 +1780,9 @@ class OrderedContractsTestCase(zf.WithAssetFinder, zf.ZiplineTestCase):
     def make_futures_info(self):
         fo_frame = pd.DataFrame(
             {
-                "root_symbol": ["FO"] * 4,
+                "root_symbol": ["FOOBAR"] * 4,
                 "asset_name": ["Foo"] * 4,
-                "symbol": ["FOF16", "FOG16", "FOH16", "FOJ16"],
+                "symbol": ["FOOBARF16", "FOOBARG16", "FOOBARH16", "FOOBARJ16"],
                 "sid": range(1, 5),
                 "start_date": pd.date_range("2015-01-01", periods=4, tz="UTC"),
                 "end_date": pd.date_range("2016-01-01", periods=4, tz="UTC"),
@@ -1860,7 +1867,7 @@ class OrderedContractsTestCase(zf.WithAssetFinder, zf.ZiplineTestCase):
 
         contracts = deque(self.asset_finder.retrieve_all(contract_sids))
 
-        oc = OrderedContracts("FO", contracts)
+        oc = OrderedContracts("FOOBAR", contracts)
 
         assert 1 == oc.contract_at_offset(
             1, 0, start_dates[-1].value
@@ -1879,7 +1886,7 @@ class OrderedContractsTestCase(zf.WithAssetFinder, zf.ZiplineTestCase):
 
         contracts = deque(self.asset_finder.retrieve_all(contract_sids))
 
-        oc = OrderedContracts("FO", contracts)
+        oc = OrderedContracts("FOOBAR", contracts)
 
         # Test sid 1 as days increment, as the sessions march forward
         # a contract should be added per day, until all defined contracts


### PR DESCRIPTION
This should allow more than 3 characters for root_symbol.
I have no idea why `_encode_continuous_future_sid` was written in such an obfuscated way and if I am missing something important there.
Anyway, I have re-written `test_continuous_futures.py` to test for a root_symbol with 6 characters and all the tests are passing.
This should close #91 