### PR TITLE
fix: generalize values for before_trading_start_minutes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,7 @@ classifiers = [
     'Topic :: System :: Distributed Computing',
 ]
 
-license = "Apache-2.0"
-license-files = [
-    "LICENSE",
-]
+license = {text = "Apache-2.0"}
 
 requires-python = '>=3.10'
 dependencies = [

--- a/src/zipline/algorithm.py
+++ b/src/zipline/algorithm.py
@@ -527,7 +527,7 @@ class TradingAlgorithm:
         before_trading_start_minutes = days_at_time(
             self.sim_params.sessions,
             before_trading_time,
-            self.trading_calendar.tz.zone,
+            str(self.trading_calendar.tz),
             day_offset=0,
         )
 

--- a/src/zipline/algorithm.py
+++ b/src/zipline/algorithm.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable
 from collections import namedtuple
 from copy import copy
 import warnings
-from datetime import tzinfo, time, timezone
+from datetime import tzinfo, time, timezone, timedelta, date, datetime
 import logging
 import pytz
 import pandas as pd
@@ -516,11 +516,18 @@ class TradingAlgorithm:
                 execution_closes = market_closes
                 execution_opens = market_closes
 
-        # FIXME generalize these values
+        # Default to 8:45am if trading_calendar doesn't have valid open_time
+        before_trading_time = time(8,45)
+        for open_time in self.trading_calendar.open_times:
+            if open_time[0] is None and open_time[1] is not None:
+                opentime = datetime.combine(date(1,1,1), open_time[1])
+                before_trading_time = (opentime - timedelta(minutes=45)).time()
+                break
+
         before_trading_start_minutes = days_at_time(
             self.sim_params.sessions,
-            time(8, 45),
-            "US/Eastern",
+            before_trading_time,
+            self.trading_calendar.tz.zone,
             day_offset=0,
         )
 

--- a/src/zipline/assets/asset_writer.py
+++ b/src/zipline/assets/asset_writer.py
@@ -319,7 +319,7 @@ def _check_symbol_mappings(df, exchanges, asset_exchange):
             ambiguous[persymbol.name] = intersections, msg_component
 
     mappings.groupby(["symbol", "country_code"], group_keys=False).apply(
-        check_intersections
+        check_intersections, include_groups=False
     )
 
     if ambiguous:

--- a/src/zipline/assets/asset_writer.py
+++ b/src/zipline/assets/asset_writer.py
@@ -318,7 +318,7 @@ def _check_symbol_mappings(df, exchanges, asset_exchange):
             msg_component = "\n  ".join(str(data).splitlines())
             ambiguous[persymbol.name] = intersections, msg_component
 
-    mappings.groupby(["symbol", "country_code"], group_keys=False).apply(
+    mappings.groupby(["symbol", "country_code"], group_keys=False, include_groups=False).apply(
         check_intersections
     )
 
@@ -380,7 +380,7 @@ def _split_symbol_mappings(df, exchanges):
 
     _check_symbol_mappings(mappings, exchanges, asset_exchange)
     return (
-        df.groupby(level=0, group_keys=False).apply(_check_asset_group),
+        df.groupby(level=0, group_keys=False, include_groups=False).apply(_check_asset_group),
         mappings,
     )
 

--- a/src/zipline/assets/asset_writer.py
+++ b/src/zipline/assets/asset_writer.py
@@ -318,7 +318,7 @@ def _check_symbol_mappings(df, exchanges, asset_exchange):
             msg_component = "\n  ".join(str(data).splitlines())
             ambiguous[persymbol.name] = intersections, msg_component
 
-    mappings.groupby(["symbol", "country_code"], group_keys=False, include_groups=False).apply(
+    mappings.groupby(["symbol", "country_code"], group_keys=False).apply(
         check_intersections
     )
 
@@ -380,7 +380,7 @@ def _split_symbol_mappings(df, exchanges):
 
     _check_symbol_mappings(mappings, exchanges, asset_exchange)
     return (
-        df.groupby(level=0, group_keys=False, include_groups=False).apply(_check_asset_group),
+        df.groupby(level=0, group_keys=False).apply(_check_asset_group),
         mappings,
     )
 

--- a/src/zipline/data/_equities.pyx
+++ b/src/zipline/data/_equities.pyx
@@ -31,7 +31,7 @@ from numpy cimport (
     uint32_t,
     uint8_t,
 )
-from numpy.math cimport NAN
+from libc.math cimport NAN
 ctypedef object carray_t
 ctypedef object ctable_t
 ctypedef object Timestamp_t

--- a/src/zipline/data/_equities.pyx
+++ b/src/zipline/data/_equities.pyx
@@ -29,6 +29,7 @@ from numpy cimport (
     intp_t,
     ndarray,
     uint32_t,
+    uint64_t,
     uint8_t,
 )
 from libc.math cimport NAN
@@ -178,8 +179,10 @@ cpdef _read_bcolz_data(ctable_t table,
         int nassets
         str column_name
         carray_t carray
-        ndarray[dtype=uint32_t, ndim=1] raw_data
-        ndarray[dtype=uint32_t, ndim=2] outbuf
+        ndarray[dtype=uint32_t, ndim=1] raw_data_uint32
+        ndarray[dtype=uint64_t, ndim=1] raw_data_uint64
+        ndarray[dtype=uint32_t, ndim=2] outbuf_uint32
+        ndarray[dtype=uint64_t, ndim=2] outbuf_uint64
         ndarray[dtype=uint8_t, ndim=2, cast=True] where_nan
         ndarray[dtype=float64_t, ndim=2] outbuf_as_float
         intp_t asset
@@ -196,48 +199,85 @@ cpdef _read_bcolz_data(ctable_t table,
         raise ValueError("Incompatible index arrays.")
 
     for column_name in columns:
-        outbuf = zeros(shape=shape, dtype=uint32)
-        if read_all:
-            raw_data = table[column_name][:]
+        if column_name == 'volume':
+            # Handle volume as uint64 to accommodate large values
+            outbuf_uint64 = zeros(shape=shape, dtype=uint64)
+            if read_all:
+                raw_data_uint64 = table[column_name][:]
 
-            for asset in range(nassets):
-                first_row = first_rows[asset]
-                if first_row == -1:
-                    # This is an unknown asset, leave its slot empty.
-                    continue
+                for asset in range(nassets):
+                    first_row = first_rows[asset]
+                    if first_row == -1:
+                        # This is an unknown asset, leave its slot empty.
+                        continue
 
-                last_row = last_rows[asset]
-                offset = offsets[asset]
+                    last_row = last_rows[asset]
+                    offset = offsets[asset]
 
-                if first_row <= last_row:
-                    outbuf[offset:offset + (last_row + 1 - first_row), asset] =\
-                        raw_data[first_row:last_row + 1]
-                else:
-                    continue
+                    if first_row <= last_row:
+                        outbuf_uint64[offset:offset + (last_row + 1 - first_row), asset] =\
+                            raw_data_uint64[first_row:last_row + 1]
+                    else:
+                        continue
+            else:
+                carray = table[column_name]
+
+                for asset in range(nassets):
+                    first_row = first_rows[asset]
+                    if first_row == -1:
+                        # This is an unknown asset, leave its slot empty.
+                        continue
+
+                    last_row = last_rows[asset]
+                    offset = offsets[asset]
+                    if first_row <= last_row:
+                        outbuf_uint64[offset:offset + (last_row + 1 - first_row), asset] =\
+                            carray[first_row:last_row + 1]
+                    else:
+                        continue
+            results.append(outbuf_uint64)
         else:
-            carray = table[column_name]
+            # Handle other columns as uint32
+            outbuf_uint32 = zeros(shape=shape, dtype=uint32)
+            if read_all:
+                raw_data_uint32 = table[column_name][:]
 
-            for asset in range(nassets):
-                first_row = first_rows[asset]
-                if first_row == -1:
-                    # This is an unknown asset, leave its slot empty.
-                    continue
+                for asset in range(nassets):
+                    first_row = first_rows[asset]
+                    if first_row == -1:
+                        # This is an unknown asset, leave its slot empty.
+                        continue
 
-                last_row = last_rows[asset]
-                offset = offsets[asset]
-                out_start = offset
-                out_end = (last_row - first_row) + offset + 1
-                if first_row <= last_row:
-                    outbuf[offset:offset + (last_row + 1 - first_row), asset] =\
-                        carray[first_row:last_row + 1]
-                else:
-                    continue
+                    last_row = last_rows[asset]
+                    offset = offsets[asset]
 
-        if column_name in {'open', 'high', 'low', 'close'}:
-            where_nan = (outbuf == 0)
-            outbuf_as_float = outbuf.astype(float64) * .001
-            outbuf_as_float[where_nan] = NAN
-            results.append(outbuf_as_float)
-        else:
-            results.append(outbuf)
+                    if first_row <= last_row:
+                        outbuf_uint32[offset:offset + (last_row + 1 - first_row), asset] =\
+                            raw_data_uint32[first_row:last_row + 1]
+                    else:
+                        continue
+            else:
+                carray = table[column_name]
+
+                for asset in range(nassets):
+                    first_row = first_rows[asset]
+                    if first_row == -1:
+                        # This is an unknown asset, leave its slot empty.
+                        continue
+
+                    last_row = last_rows[asset]
+                    offset = offsets[asset]
+                    if first_row <= last_row:
+                        outbuf_uint32[offset:offset + (last_row + 1 - first_row), asset] =\
+                            carray[first_row:last_row + 1]
+                    else:
+                        continue
+
+            if column_name in {'open', 'high', 'low', 'close'}:
+                where_nan = (outbuf_uint32 == 0)
+                outbuf_as_float = outbuf_uint32.astype(float64) * .001
+                outbuf_as_float[where_nan] = NAN
+                results.append(outbuf_as_float)
+            else:
+                results.append(outbuf_uint32)
     return results

--- a/src/zipline/data/_equities.pyx
+++ b/src/zipline/data/_equities.pyx
@@ -22,6 +22,7 @@ from numpy import (
     full,
     intp,
     uint32,
+    uint64,
     zeros,
 )
 from numpy cimport (

--- a/src/zipline/data/bcolz_daily_bars.py
+++ b/src/zipline/data/bcolz_daily_bars.py
@@ -30,7 +30,7 @@ from zipline.utils.cli import maybe_show_progress
 from zipline.utils.functional import apply
 from zipline.utils.input_validation import expect_element
 from zipline.utils.memoize import lazyval
-from zipline.utils.numpy_utils import float64_dtype, iNaT, uint32_dtype
+from zipline.utils.numpy_utils import float64_dtype, iNaT, uint32_dtype, uint64_dtype
 
 from ._equities import _compute_row_slices, _read_bcolz_data
 
@@ -65,46 +65,75 @@ def winsorise_uint32(df, invalid_data_behavior, column, *columns):
         The dataframe to winsorise.
     invalid_data_behavior : {'warn', 'raise', 'ignore'}
         What to do when data is outside the bounds of a uint32.
+    column : str
+        The name of the first column to check.
     *columns : iterable[str]
-        The names of the columns to check.
+        Additional names of the columns to check.
 
     Returns
     -------
     truncated : pd.DataFrame
         ``df`` with values that do not fit into a uint32 zeroed out.
     """
-    columns = list((column,) + columns)
-    mask = df[columns] > UINT32_MAX
+    all_columns = [column] + list(columns)
+    # Exclude 'volume' from uint32 checking since it can legitimately exceed uint32 limits
+    columns_to_check = [col for col in all_columns if col != 'volume']
 
-    if invalid_data_behavior != "ignore":
-        mask |= df[columns].isnull()
+    if columns_to_check:
+        # Create boolean mask for values that exceed uint32 max
+        mask = df[columns_to_check] > UINT32_MAX
+
+        if invalid_data_behavior != "ignore":
+            # Add null values to the mask if we're not ignoring them
+            null_mask = df[columns_to_check].isnull()
+            mask = mask | null_mask
+        else:
+            # we are not going to generate a warning or error for this so just use
+            # nan_to_num
+            df[columns_to_check] = np.nan_to_num(df[columns_to_check])
+
+        # Check if any values need to be winsorized
+        mv = mask.values
+        if mv.any():
+            if invalid_data_behavior == "raise":
+                raise ValueError(
+                    "%d values out of bounds for uint32: %r"
+                    % (
+                        mv.sum(),
+                        df[mask.any(axis=1)][columns_to_check],
+                    ),
+                )
+            if invalid_data_behavior == "warn":
+                warnings.warn(
+                    "Ignoring %d values because they are out of bounds for"
+                    " uint32:\n %r"
+                    % (
+                        mv.sum(),
+                        df[mask.any(axis=1)][columns_to_check],
+                    ),
+                    stacklevel=3,  # one extra frame for `expect_element`
+                )
+
+            # Apply winsorization by setting out-of-bounds values to 0
+            # Use integer indexing to avoid the character issue
+            for col in columns_to_check:
+                col_mask = mask[col]
+                df.loc[col_mask, col] = 0
     else:
-        # we are not going to generate a warning or error for this so just use
-        # nan_to_num
-        df[columns] = np.nan_to_num(df[columns])
+        # If only volume was passed, still need to handle null values if needed
+        if invalid_data_behavior != "ignore":
+            volume_mask = df[['volume']].isnull()
+            if volume_mask.any().any():
+                if invalid_data_behavior == "raise":
+                    raise ValueError(
+                        "Null values found in volume column"
+                    )
+                if invalid_data_behavior == "warn":
+                    warnings.warn(
+                        "Null values found in volume column",
+                        stacklevel=3,
+                    )
 
-    mv = mask.values
-    if mv.any():
-        if invalid_data_behavior == "raise":
-            raise ValueError(
-                "%d values out of bounds for uint32: %r"
-                % (
-                    mv.sum(),
-                    df[mask.any(axis=1)],
-                ),
-            )
-        if invalid_data_behavior == "warn":
-            warnings.warn(
-                "Ignoring %d values because they are out of bounds for"
-                " uint32:\n %r"
-                % (
-                    mv.sum(),
-                    df[mask.any(axis=1)],
-                ),
-                stacklevel=3,  # one extra frame for `expect_element`
-            )
-
-    df[mask] = 0
     return df
 
 
@@ -232,10 +261,13 @@ class BcolzDailyBarWriter:
         calendar_offset = {}
 
         # Maps column name -> output carray.
-        columns = {
-            k: carray(np.array([], dtype=uint32_dtype))
-            for k in US_EQUITY_PRICING_BCOLZ_COLUMNS
-        }
+        # Volume column needs to be uint64 to handle large values
+        columns = {}
+        for k in US_EQUITY_PRICING_BCOLZ_COLUMNS:
+            if k == 'volume':
+                columns[k] = carray(np.array([], dtype=uint64_dtype))
+            else:
+                columns[k] = carray(np.array([], dtype=uint32_dtype))
 
         earliest_date = None
         sessions = self._calendar.sessions_in_range(
@@ -338,12 +370,14 @@ class BcolzDailyBarWriter:
             # we already have a ctable so do nothing
             return raw_data
 
+        # Process OHLC prices separately from volume since volume can exceed uint32 limits
         winsorise_uint32(raw_data, invalid_data_behavior, "volume", *OHLC)
         processed = (raw_data[list(OHLC)] * 1000).round().astype("uint32")
         dates = raw_data.index.values.astype("datetime64[s]")
         check_uint32_safe(dates.max().view(np.int64), "day")
         processed["day"] = dates.astype("uint32")
-        processed["volume"] = raw_data.volume.astype("uint32")
+        # Handle volume separately as uint64 to accommodate large volume values
+        processed["volume"] = raw_data.volume.astype("uint64")
         return ctable.fromdataframe(processed)
 
 

--- a/src/zipline/data/bcolz_minute_bars.py
+++ b/src/zipline/data/bcolz_minute_bars.py
@@ -158,19 +158,19 @@ def convert_cols(cols, scale_factor, sid, invalid_data_behavior):
             # this column.
             exclude_mask &= scaled_col >= np.iinfo(np.uint32).max
 
-    # Convert all cols to uint32.
+    # Convert OHLC cols to uint32.
     opens = scaled_opens.astype(np.uint32)
     highs = scaled_highs.astype(np.uint32)
     lows = scaled_lows.astype(np.uint32)
     closes = scaled_closes.astype(np.uint32)
-    volumes = cols["volume"].astype(np.uint32)
+    # Handle volume separately as uint64 to accommodate large volume values
+    volumes = cols["volume"].astype(np.uint64)
 
-    # Exclude rows with unsafe values by setting to zero.
+    # Exclude rows with unsafe values by setting to zero for OHLC only.
     opens[exclude_mask] = 0
     highs[exclude_mask] = 0
     lows[exclude_mask] = 0
     closes[exclude_mask] = 0
-    volumes[exclude_mask] = 0
 
     return opens, highs, lows, closes, volumes
 
@@ -368,7 +368,7 @@ class BcolzMinuteBarWriter:
     the quoted price, so that the data can represented and stored as an
     np.uint32, supporting market prices quoted up to the thousands place.
 
-    volume is a np.uint32 with no mutation of the tens place.
+    volume is a np.uint64 to accommodate large volume values.
 
     The 'index' for each individual asset are a repeating period of minutes of
     length `minutes_per_day` starting from each market open.

--- a/src/zipline/data/hdf5_daily_bars.py
+++ b/src/zipline/data/hdf5_daily_bars.py
@@ -164,6 +164,13 @@ def coerce_to_uint32(a, scaling_factor):
     return (a * scaling_factor).round().astype("uint32")
 
 
+def coerce_volume_to_uint64(a, scaling_factor):
+    """
+    Returns a copy of the volume array as uint64 to accommodate large values.
+    """
+    return (a * scaling_factor).round().astype("uint64")
+
+
 def days_and_sids_for_frames(frames):
     """
     Returns the date index and sid columns shared by a list of dataframes,
@@ -399,10 +406,16 @@ class HDF5DailyBarWriter:
             frame.sort_index(inplace=True)
             frame.sort_index(axis="columns", inplace=True)
 
-            data = coerce_to_uint32(
-                frame.T.fillna(0).values,
-                scaling_factors[field],
-            )
+            if field == VOLUME:
+                data = coerce_volume_to_uint64(
+                    frame.T.fillna(0).values,
+                    scaling_factors[field],
+                )
+            else:
+                data = coerce_to_uint32(
+                    frame.T.fillna(0).values,
+                    scaling_factors[field],
+                )
 
             dataset = data_group.create_dataset(
                 field,

--- a/src/zipline/finance/_finance_ext.pyx
+++ b/src/zipline/finance/_finance_ext.pyx
@@ -132,6 +132,15 @@ cpdef calculate_position_tracker_stats(positions, PositionStats stats):
     cdef np.ndarray[np.float64_t] old_position_exposure = (
         stats.underlying_value_array
     )
+    
+    # Ensure the original arrays are writeable from the start
+    if not old_index.flags.writeable:
+        old_index = old_index.copy()
+        stats.underlying_index_array = old_index
+        
+    if not old_position_exposure.flags.writeable:
+        old_position_exposure = old_position_exposure.copy()
+        stats.underlying_value_array = old_position_exposure
 
     cdef np.float64_t value
     cdef np.float64_t exposure
@@ -170,6 +179,15 @@ cpdef calculate_position_tracker_stats(positions, PositionStats stats):
         # available
         index = old_index[:npos]
         position_exposure = old_position_exposure[:npos]
+        
+        # Ensure both arrays are writeable
+        if not index.flags.writeable:
+            index = index.copy()
+            stats.underlying_index_array = index
+            
+        if not position_exposure.flags.writeable:
+            position_exposure = position_exposure.copy()
+            stats.underlying_value_array = position_exposure
 
         stats.position_exposure_array = position_exposure
         # create a new series with the sliced arrays
@@ -182,6 +200,15 @@ cpdef calculate_position_tracker_stats(positions, PositionStats stats):
         # needed
         index = old_index
         position_exposure = old_position_exposure
+        
+        # Ensure both arrays are writeable
+        if not index.flags.writeable:
+            index = index.copy()
+            stats.underlying_index_array = index
+            
+        if not position_exposure.flags.writeable:
+            position_exposure = position_exposure.copy()
+            stats.underlying_value_array = position_exposure
 
         stats.position_exposure_array = position_exposure
         stats.position_exposure_series = pd.Series(

--- a/src/zipline/pipeline/loaders/earnings_estimates.py
+++ b/src/zipline/pipeline/loaders/earnings_estimates.py
@@ -476,7 +476,7 @@ class EarningsEstimatesLoader(PipelineLoader):
 
         col_to_all_adjustments = {}
         sid_to_idx = dict(zip(assets, range(len(assets))))
-        quarter_shifts.groupby(level=SID_FIELD_NAME).apply(
+        quarter_shifts.groupby(level=SID_FIELD_NAME, include_groups=False).apply(
             self.get_adjustments_for_sid,
             dates,
             requested_qtr_data,

--- a/src/zipline/pipeline/loaders/earnings_estimates.py
+++ b/src/zipline/pipeline/loaders/earnings_estimates.py
@@ -476,7 +476,7 @@ class EarningsEstimatesLoader(PipelineLoader):
 
         col_to_all_adjustments = {}
         sid_to_idx = dict(zip(assets, range(len(assets))))
-        quarter_shifts.groupby(level=SID_FIELD_NAME, include_groups=False).apply(
+        quarter_shifts.groupby(level=SID_FIELD_NAME).apply(
             self.get_adjustments_for_sid,
             dates,
             requested_qtr_data,


### PR DESCRIPTION
In original zipline, the before_trading_start_minutes is fixed as 8:45AM US/Eastern timezone. But that won't fit if the security market is in different location. Using (open time - 45min) and timezone info to support different timezone markets. 

One tricky is exchange_calendars is moving from pytz to zoneinfo. It seems str() is the best function to convert timezone (expressed in both pytz and zoneinfo) to timezone string.