### PR TITLE
Amend docstrings for bcolz writer classes to clarify whether data is appended or overwritten

### DIFF
--- a/src/zipline/data/bcolz_daily_bars.py
+++ b/src/zipline/data/bcolz_daily_bars.py
@@ -163,6 +163,7 @@ class BcolzDailyBarWriter:
         self, data, assets=None, show_progress=False, invalid_data_behavior="warn"
     ):
         """
+        Write a stream of daily data.  Any existing data in the file is overwritten.
 
         Parameters
         ----------

--- a/src/zipline/data/bcolz_minute_bars.py
+++ b/src/zipline/data/bcolz_minute_bars.py
@@ -627,7 +627,7 @@ class BcolzMinuteBarWriter:
             table.attrs[k] = v
 
     def write(self, data, show_progress=False, invalid_data_behavior="warn"):
-        """Write a stream of minute data.
+        """Append a stream of minute data to the existing file.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixes #225.