### PR TITLE
fix future warnings

### DIFF
--- a/src/zipline/finance/ledger.py
+++ b/src/zipline/finance/ledger.py
@@ -417,11 +417,11 @@ class Ledger:
         # make daily_returns hold the partial returns, this saves many
         # metrics from doing a concat and copying all of the previous
         # returns
-        self.daily_returns_array[session_ix] = self.todays_returns
+        self.daily_returns_array.iloc[session_ix] = self.todays_returns
 
     def end_of_session(self, session_ix):
         # save the daily returns time-series
-        self.daily_returns_series[session_ix] = self.todays_returns
+        self.daily_returns_series.iloc[session_ix] = self.todays_returns
 
     def sync_last_sale_prices(self, dt, data_portal, handle_non_market_minutes=False):
         self.position_tracker.sync_last_sale_prices(


### PR DESCRIPTION
@stefan-jansen , please review

this is to fix the `FutureWarning` on `ledger.py:424`

```
/home/gordon/.local/lib/python3.11/site-packages/zipline/finance/ledger.py:424: FutureWarning: Series.__setitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To set a value by position, use `ser.iloc[pos] = value`
  self.daily_returns_series[session_ix] = self.todays_returns

```

On branch future_warning
Changes to be committed:
	modified:   src/zipline/finance/ledger.py