### PR TITLE
Fixed missing ")" error

### DIFF
--- a/docs/source/beginner-tutorial.rst
+++ b/docs/source/beginner-tutorial.rst
@@ -536,7 +536,7 @@ magic.
 
    def handle_data(context, data):
        order(symbol('AAPL'), 10)
-       record(AAPL=data.current(symbol('AAPL'), "price")
+       record(AAPL=data.current(symbol('AAPL'), "price"))
 
 Note that we did not have to specify an input file as above since the
 magic will use the contents of the cell and look for your algorithm


### PR DESCRIPTION
```record(AAPL=data.current(symbol('AAPL'), "price")```, lacks a closing bracket. I added this bracket to ensure beginners will not get stuck.