### PR TITLE
Fix warnings related to Pandas 2.1.0

### DIFF
--- a/src/zipline/_protocol.pyx
+++ b/src/zipline/_protocol.pyx
@@ -659,7 +659,7 @@ cdef class BarData:
             df = (pd.concat(df_dict,
                             keys=df_dict.keys(),
                             names=['fields', dt_label])
-                  .stack(dropna=False)  # ensure we return all fields/assets/dates despite missing values
+                  .stack(future_stack=True)  # ensure we return all fields/assets/dates despite missing values
                   .unstack(level='fields'))
             df.index.set_names([dt_label, 'asset'])
             return df.sort_index()

--- a/src/zipline/data/data_portal.py
+++ b/src/zipline/data/data_portal.py
@@ -948,7 +948,7 @@ class DataPortal:
             df.iloc[0, assets_with_leading_nan] = np.array(
                 initial_values, dtype=np.float64
             )
-            df.fillna(method="ffill", inplace=True)
+            df.ffill(inplace=True)
 
             # forward-filling will incorrectly produce values after the end of
             # an asset's lifetime, so write NaNs back over the asset's

--- a/src/zipline/pipeline/loaders/earnings_estimates.py
+++ b/src/zipline/pipeline/loaders/earnings_estimates.py
@@ -702,7 +702,8 @@ class EarningsEstimatesLoader(implements(PipelineLoader)):
         ffill_across_cols(last_per_qtr, columns, self.name_map)
         # Stack quarter and sid into the index.
         stacked_last_per_qtr = last_per_qtr.stack(
-            [SID_FIELD_NAME, NORMALIZED_QUARTERS], future_stack=True,
+            [SID_FIELD_NAME, NORMALIZED_QUARTERS],
+            future_stack=True,
         )
         # Set date index name for ease of reference
         stacked_last_per_qtr.index.set_names(

--- a/src/zipline/pipeline/loaders/earnings_estimates.py
+++ b/src/zipline/pipeline/loaders/earnings_estimates.py
@@ -702,7 +702,7 @@ class EarningsEstimatesLoader(implements(PipelineLoader)):
         ffill_across_cols(last_per_qtr, columns, self.name_map)
         # Stack quarter and sid into the index.
         stacked_last_per_qtr = last_per_qtr.stack(
-            [SID_FIELD_NAME, NORMALIZED_QUARTERS],
+            [SID_FIELD_NAME, NORMALIZED_QUARTERS], future_stack=True,
         )
         # Set date index name for ease of reference
         stacked_last_per_qtr.index.set_names(

--- a/tests/pipeline/test_international_markets.py
+++ b/tests/pipeline/test_international_markets.py
@@ -128,7 +128,10 @@ class WithInternationalDailyBarData(zf.WithAssetFinder):
 
             bar_data = cls.daily_bar_data[name]
             df = (
-                pd.concat(bar_data, keys=bar_data.keys()).stack(future_stack=True).unstack(0).swaplevel()
+                pd.concat(bar_data, keys=bar_data.keys())
+                .stack(future_stack=True)
+                .unstack(0)
+                .swaplevel()
             )
             frames = {
                 field: frame.reset_index(level=0, drop=True)

--- a/tests/pipeline/test_international_markets.py
+++ b/tests/pipeline/test_international_markets.py
@@ -128,7 +128,7 @@ class WithInternationalDailyBarData(zf.WithAssetFinder):
 
             bar_data = cls.daily_bar_data[name]
             df = (
-                pd.concat(bar_data, keys=bar_data.keys()).stack().unstack(0).swaplevel()
+                pd.concat(bar_data, keys=bar_data.keys()).stack(future_stack=True).unstack(0).swaplevel()
             )
             frames = {
                 field: frame.reset_index(level=0, drop=True)

--- a/tests/pipeline/test_quarters_estimates.py
+++ b/tests/pipeline/test_quarters_estimates.py
@@ -2666,7 +2666,7 @@ class PreviousWithAdjustmentBoundaries(WithAdjustmentBoundaries, ZiplineTestCase
             .set_index(SID_FIELD_NAME, append=True)
             .unstack(SID_FIELD_NAME)
             .reindex(cls.trading_days)
-            .stack(SID_FIELD_NAME, dropna=False)
+            .stack(SID_FIELD_NAME, future_stack=True)
         )
 
         split_adjusted_at_end_boundary = (
@@ -2733,7 +2733,7 @@ class PreviousWithAdjustmentBoundaries(WithAdjustmentBoundaries, ZiplineTestCase
             .set_index(SID_FIELD_NAME, append=True)
             .unstack(SID_FIELD_NAME)
             .reindex(cls.trading_days)
-            .stack(SID_FIELD_NAME, dropna=False)
+            .stack(SID_FIELD_NAME, future_stack=True)
         )
 
         split_adjusted_before_start_boundary = split_adjusted_at_start_boundary
@@ -2812,7 +2812,7 @@ class NextWithAdjustmentBoundaries(WithAdjustmentBoundaries, ZiplineTestCase):
             .set_index(SID_FIELD_NAME, append=True)
             .unstack(SID_FIELD_NAME)
             .reindex(cls.trading_days)
-            .stack(SID_FIELD_NAME, dropna=False)
+            .stack(SID_FIELD_NAME, future_stack=True)
         )
 
         split_adjusted_at_end_boundary = (
@@ -2867,7 +2867,7 @@ class NextWithAdjustmentBoundaries(WithAdjustmentBoundaries, ZiplineTestCase):
             .set_index(SID_FIELD_NAME, append=True)
             .unstack(SID_FIELD_NAME)
             .reindex(cls.trading_days)
-            .stack(SID_FIELD_NAME, dropna=False)
+            .stack(SID_FIELD_NAME, future_stack=True)
         )
 
         split_adjusted_before_start_boundary = split_adjusted_at_start_boundary


### PR DESCRIPTION
Hi,

Just updated the code to remove deprecation warnings for ffill() and stack() Pandas methods.

For more info related to these updates check the Pandas release notes:
https://pandas.pydata.org/docs/whatsnew/v2.1.0.html

![image](https://github.com/user-attachments/assets/d188ab8f-a9f5-4be9-a4d4-03022da0f757)

![image](https://github.com/user-attachments/assets/51a0591a-6bc0-4d5e-9910-f287397f47f9)


/John