### PR TITLE
fix to support latest cython 3.1.0

### DIFF
--- a/src/zipline/data/_equities.pyx
+++ b/src/zipline/data/_equities.pyx
@@ -31,7 +31,7 @@ from numpy cimport (
     uint32_t,
     uint8_t,
 )
-from numpy.math cimport NAN
+from libc.math cimport NAN
 ctypedef object carray_t
 ctypedef object ctable_t
 ctypedef object Timestamp_t


### PR DESCRIPTION
from cython 3.1.0 changelog

 >The ``numpy.math`` cimport module has been deprecated.
 > Usages should be replaced by ``libc.math``.
 > (Github issue :issue:`6743`)

to solve #280 
