### PR TITLE
BUG: Fix infinite loops and data corruption in data layer

### DIFF
--- a/docs/source/whatsnew/skeleton.txt
+++ b/docs/source/whatsnew/skeleton.txt
@@ -31,7 +31,18 @@ None
 Bug Fixes
 ~~~~~~~~~
 
-None
+- Fix ``convert_cols`` in bcolz minute bar writer to use ``|=`` instead of
+  ``&=`` for the exclude mask, so rows with uint32 overflow values are actually
+  filtered out. (:issue:`314`)
+- Fix infinite loop in ``DataPortal._get_daily_spot_value`` when searching
+  backwards for a non-NaN close price by adding a bounds check against
+  ``_first_trading_day``. (:issue:`314`)
+- Fix infinite loop in ``BcolzDailyBarReader.get_last_traded_dt`` when
+  ``NoDataAfterDate`` is raised and no previous session exists. (:issue:`314`)
+- Fix ``DataPortal.get_adjustments`` to apply ``tz_localize`` to merger
+  adjustment dates, consistent with splits and dividends. (:issue:`314`)
+- Add path traversal validation to ``tar.extractall`` in the Quandl bundle
+  loader (CVE-2007-4559). (:issue:`314`)
 
 Performance
 ~~~~~~~~~~~

--- a/src/zipline/data/bcolz_daily_bars.py
+++ b/src/zipline/data/bcolz_daily_bars.py
@@ -595,6 +595,8 @@ class BcolzDailyBarReader(CurrencyAwareSessionBarReader):
                 prev_day_ix = self.sessions.get_loc(search_day) - 1
                 if prev_day_ix > -1:
                     search_day = self.sessions[prev_day_ix]
+                else:
+                    return pd.NaT
                 continue
             except NoDataOnDate:
                 return pd.NaT

--- a/src/zipline/data/bcolz_minute_bars.py
+++ b/src/zipline/data/bcolz_minute_bars.py
@@ -156,7 +156,7 @@ def convert_cols(cols, scale_factor, sid, invalid_data_behavior):
 
             # We want to exclude all rows that have an unsafe value in
             # this column.
-            exclude_mask &= scaled_col >= np.iinfo(np.uint32).max
+            exclude_mask |= scaled_col >= np.iinfo(np.uint32).max
 
     # Convert all cols to uint32.
     opens = scaled_opens.astype(np.uint32)

--- a/src/zipline/data/bundles/quandl.py
+++ b/src/zipline/data/bundles/quandl.py
@@ -3,6 +3,7 @@ Module for building a complete daily dataset from Quandl's WIKI dataset.
 """
 
 from io import BytesIO
+import os
 import tarfile
 from zipfile import ZipFile
 
@@ -310,6 +311,15 @@ def quantopian_quandl_bundle(
     with tarfile.open("r", fileobj=data) as tar:
         if show_progress:
             log.info("Writing data to %s.", output_dir)
+        for member in tar.getmembers():
+            member_path = os.path.join(output_dir, member.name)
+            if not os.path.realpath(member_path).startswith(
+                os.path.realpath(output_dir)
+            ):
+                raise ValueError(
+                    f"Tar member {member.name!r} would extract outside "
+                    f"target directory"
+                )
         tar.extractall(output_dir)
 
 

--- a/src/zipline/data/data_portal.py
+++ b/src/zipline/data/data_portal.py
@@ -595,9 +595,9 @@ class DataPortal:
                     asset, self._mergers_dict, "MERGERS"
                 )
                 for adj_dt, adj in merger_adjustments:
-                    if dt < adj_dt <= perspective_dt:
+                    if dt < adj_dt.tz_localize(dt.tzinfo) <= perspective_dt:
                         adjustments_for_asset.append(adj)
-                    elif adj_dt > perspective_dt:
+                    elif adj_dt.tz_localize(dt.tzinfo) > perspective_dt:
                         break
 
                 dividend_adjustments = self._get_adjustment_list(
@@ -738,6 +738,8 @@ class DataPortal:
                             )
                     else:
                         found_dt -= self.trading_calendar.day
+                        if found_dt < self._first_trading_day:
+                            return np.nan
                 except NoDataOnDate:
                     return np.nan
 


### PR DESCRIPTION
## Summary

Fixes 5 data layer bugs including 2 infinite loops, a data corruption issue, a timezone inconsistency, and a security vulnerability:

- **Exclude mask operator**: `convert_cols` used `&=` instead of `|=` for the exclude mask, meaning rows were never excluded unless every column overflowed simultaneously.
- **Infinite loop in spot value**: `DataPortal._get_daily_spot_value` looped infinitely searching backwards for a non-NaN close price with no bounds check against `_first_trading_day`.
- **Infinite loop in last traded**: `BcolzDailyBarReader.get_last_traded_dt` looped infinitely when `prev_day_ix` reached -1.
- **Merger tz mismatch**: Merger adjustment dates were not tz-localized, unlike splits and dividends, causing comparison failures.
- **Path traversal (CVE-2007-4559)**: `tar.extractall()` in the Quandl bundle had no path validation.

Closes #314

## Test plan

- [x] Full test suite passes (3142 tests, 11 pre-existing pandas 2.3 failures)
- [x] flake8 clean on all modified files