### PR TITLE
BUG: Fix asset writer, memoize cache, and event scheduling bugs

### DIFF
--- a/docs/source/whatsnew/skeleton.txt
+++ b/docs/source/whatsnew/skeleton.txt
@@ -31,7 +31,18 @@ None
 Bug Fixes
 ~~~~~~~~~
 
-None
+- Fix ``_weak_lru_cache`` double-counting cache misses and fix
+  ``cache_clear()`` crash from subscripting integer counters. (:issue:`315`)
+- Fix ``AssetFinder._lookup_symbol_strict`` to materialize ``map()`` iterator
+  to a list before reuse, preventing empty ``options`` dict in
+  ``SameSymbolUsedAcrossCountries`` error. (:issue:`315`)
+- Fix ``AssetDBWriter._all_tables_present`` to check all tables instead of
+  returning after the first one. (:issue:`315`)
+- Fix ``BeforeClose.calculate_dates`` to compare ``self.cal.name`` instead of
+  ``self.cal`` to the string ``"us_futures"``. (:issue:`315`)
+- Fix ``AssetDBWriter.write_direct`` argument order for futures, which
+  previously swapped the data and defaults arguments to
+  ``_generate_output_dataframe``. (:issue:`315`)
 
 Performance
 ~~~~~~~~~~~

--- a/src/zipline/assets/asset_writer.py
+++ b/src/zipline/assets/asset_writer.py
@@ -652,7 +652,7 @@ class AssetDBWriter:
             )
 
         if futures is not None:
-            futures = _generate_output_dataframe(_futures_defaults, futures)
+            futures = _generate_output_dataframe(futures, _futures_defaults)
 
         if exchanges is not None:
             exchanges = _generate_output_dataframe(
@@ -876,7 +876,7 @@ class AssetDBWriter:
 
     def _all_tables_present(self, txn):
         """
-        Checks if any tables are present in the current assets database.
+        Checks if all tables are present in the current assets database.
 
         Parameters
         ----------
@@ -886,14 +886,12 @@ class AssetDBWriter:
         Returns
         -------
         has_tables : bool
-            True if any tables are present, otherwise False.
+            True if all tables are present, otherwise False.
         """
-        # conn = txn.connect()
-        for table_name in asset_db_table_names:
-            return sa.inspect(txn).has_table(table_name)
-            # if txn.dialect.has_table(conn, table_name):
-            # return True
-        # return False
+        return all(
+            sa.inspect(txn).has_table(table_name)
+            for table_name in asset_db_table_names
+        )
 
     def init_db(self, txn=None):
         """Connect to database and create tables.

--- a/src/zipline/assets/assets.py
+++ b/src/zipline/assets/assets.py
@@ -804,7 +804,7 @@ class AssetFinder:
             options = {self.retrieve_asset(owner.sid) for owner in owners}
 
             if multi_country:
-                country_codes = map(attrgetter("country_code"), options)
+                country_codes = list(map(attrgetter("country_code"), options))
 
                 if len(set(country_codes)) > 1:
                     raise SameSymbolUsedAcrossCountries(

--- a/src/zipline/utils/events.py
+++ b/src/zipline/utils/events.py
@@ -428,7 +428,7 @@ class BeforeClose(StatelessRule):
         # Align the market close time here with the execution time used by the
         # simulation clock. This ensures that scheduled functions trigger at
         # the correct times.
-        if self.cal == "us_futures":
+        if self.cal.name == "us_futures":
             self._period_end = self.cal.execution_time_from_close(period_end)
         else:
             self._period_end = period_end

--- a/src/zipline/utils/memoize.py
+++ b/src/zipline/utils/memoize.py
@@ -161,7 +161,6 @@ def _weak_lru_cache(maxsize=100):
                 result = user_function(*args, **kwds)
                 with lock:
                     cache[key] = result  # record recent use of this key
-                    misses += 1
                     if cache_len() > maxsize:
                         # purge least recently used cache entry
                         cache_popitem(last=False)
@@ -176,9 +175,10 @@ def _weak_lru_cache(maxsize=100):
 
         def cache_clear():
             """Clear the cache and cache statistics"""
+            nonlocal hits, misses
             with lock:
                 cache.clear()
-                hits[0] = misses[0] = 0
+                hits = misses = 0
 
         wrapper.cache_info = cache_info
         wrapper.cache_clear = cache_clear


### PR DESCRIPTION
## Summary

Fixes 5 bugs in asset management, caching, and event scheduling utilities:

- **LRU cache**: `_weak_lru_cache` double-counted misses and `cache_clear()` crashed trying to subscript integer counters.
- **Iterator exhaustion**: `_lookup_symbol_strict` assigned `map()` to `country_codes`, which was consumed by `set()` and empty when passed to the error constructor.
- **Table check short-circuit**: `_all_tables_present` returned after checking only the first table due to `return` inside the loop.
- **Calendar comparison**: `BeforeClose` compared a calendar object to the string `"us_futures"` (always `False`) instead of comparing `self.cal.name`.
- **Argument swap**: `write_direct` passed `(_futures_defaults, futures)` to `_generate_output_dataframe` which expects `(data, defaults)`.

Closes #315

## Test plan

- [x] Full test suite passes (3142 tests, 11 pre-existing pandas 2.3 failures)
- [x] flake8 clean on all modified files