### PR TITLE
Fix pandas 2.0+ and numpy 2.0+ compatibility issues

### DIFF
--- a/docs/source/whatsnew/skeleton.txt
+++ b/docs/source/whatsnew/skeleton.txt
@@ -31,7 +31,17 @@ None
 Bug Fixes
 ~~~~~~~~~
 
-None
+- Fix ``DataFrame.tz_localize()`` removal in pandas 2.0+ when reading benchmark
+  returns (:issue:`xxx`).
+- Fix ``np.isnan()`` on integer (uint32) volume values in HDF5 daily bar reader
+  (:issue:`xxx`).
+- Fix ``DatetimeIndex.freq`` returning ``None`` in pandas 2.0+ for session-based
+  date arithmetic in ``BcolzMinuteBarWriter``, ``ContinuousFutureSessionBarReader``,
+  and ``ContinuousFutureMinuteBarReader`` (:issue:`xxx`).
+- Fix timezone-naive vs timezone-aware timestamp comparison in
+  ``_ClassicRiskMetrics._periods_in_range`` (:issue:`xxx`).
+- Replace deprecated ``pd.Timestamp.utcnow()`` with ``pd.Timestamp.now("UTC")``
+  (:issue:`xxx`).
 
 Performance
 ~~~~~~~~~~~

--- a/src/zipline/data/benchmarks.py
+++ b/src/zipline/data/benchmarks.py
@@ -40,7 +40,7 @@ def get_benchmark_returns_from_file(filelike):
         parse_dates=["date"],
     )
     if df.index.tz is not None:
-        df = df.tz_localize(None)
+        df.index = df.index.tz_localize(None)
 
     if "return" not in df.columns:
         raise ValueError(

--- a/src/zipline/data/bundles/core.py
+++ b/src/zipline/data/bundles/core.py
@@ -406,7 +406,7 @@ def _make_bundle_core():
             end_session = calendar.last_session
 
         if timestamp is None:
-            timestamp = pd.Timestamp.utcnow()
+            timestamp = pd.Timestamp.now("UTC")
         timestamp = timestamp.tz_convert("utc").tz_localize(None)
 
         timestr = to_bundle_ingest_dirname(timestamp)
@@ -551,7 +551,7 @@ def _make_bundle_core():
             The raw data readers for this bundle.
         """
         if timestamp is None:
-            timestamp = pd.Timestamp.utcnow()
+            timestamp = pd.Timestamp.now("UTC")
         timestr = most_recent_data(name, timestamp, environ=environ)
         return BundleData(
             asset_finder=AssetFinder(

--- a/src/zipline/data/continuous_future_reader.py
+++ b/src/zipline/data/continuous_future_reader.py
@@ -60,7 +60,7 @@ class ContinuousFutureSessionBarReader(SessionBarReader):
                 start_loc = sessions.get_loc(start)
 
                 if roll_date is not None:
-                    end = roll_date - sessions.freq
+                    end = roll_date - tc.day
                     end_loc = sessions.get_loc(end)
                 else:
                     end = end_date
@@ -228,11 +228,6 @@ class ContinuousFutureMinuteBarReader(SessionBarReader):
                 asset.root_symbol, start_session, end_session, asset.offset
             )
 
-        sessions = tc.sessions_in_range(
-            start_date.normalize().tz_localize(None),
-            end_date.normalize().tz_localize(None),
-        )
-
         minutes = tc.minutes_in_range(start_date, end_date)
         num_minutes = len(minutes)
         shape = num_minutes, len(assets)
@@ -250,7 +245,7 @@ class ContinuousFutureMinuteBarReader(SessionBarReader):
                 sid, roll_date = roll
                 start_loc = minutes.searchsorted(start)
                 if roll_date is not None:
-                    end = tc.session_close(roll_date - sessions.freq)
+                    end = tc.session_close(roll_date - tc.day)
                     end_loc = minutes.searchsorted(end)
                 else:
                     end = end_date

--- a/src/zipline/data/fx/hdf5.py
+++ b/src/zipline/data/fx/hdf5.py
@@ -277,7 +277,7 @@ class HDF5FXRateWriter:
 
     def _write_metadata(self):
         self._group.attrs["version"] = HDF5_FX_VERSION
-        self._group.attrs["last_updated_utc"] = str(pd.Timestamp.utcnow())
+        self._group.attrs["last_updated_utc"] = str(pd.Timestamp.now("UTC"))
 
     def _write_index_group(self, dts, currencies):
         """Write content of /index."""

--- a/src/zipline/data/hdf5_daily_bars.py
+++ b/src/zipline/data/hdf5_daily_bars.py
@@ -782,7 +782,7 @@ class HDF5DailyBarReader(CurrencyAwareSessionBarReader):
         # If that's the case, the proper NoDataOnDate exception is raised.
         # Otherwise (when there's just a hole in the middle of the data), the
         # nan is returned.
-        if np.isnan(value):
+        if np.issubdtype(np.asarray(value).dtype, np.floating) and np.isnan(value):
             if dt.asm8 < self.asset_start_dates[sid_ix]:
                 raise NoDataBeforeDate()
 

--- a/src/zipline/finance/metrics/metric.py
+++ b/src/zipline/finance/metrics/metric.py
@@ -539,7 +539,7 @@ class _ClassicRiskMetrics:
             return
 
         tzinfo = end_date.tzinfo
-        end_date = end_date
+        end_date = end_date.tz_localize(None) if end_date.tzinfo is not None else end_date
         for period_timestamp in months:
             period = period_timestamp.tz_localize(None).to_period(
                 freq="%dM" % months_per
@@ -547,9 +547,10 @@ class _ClassicRiskMetrics:
             if period.end_time > end_date:
                 break
 
+            end_session_naive = end_session.tz_localize(None) if end_session.tzinfo is not None else end_session
             yield cls.risk_metric_period(
                 start_session=period.start_time.tz_localize(tzinfo),
-                end_session=min(period.end_time, end_session).tz_localize(tzinfo),
+                end_session=min(period.end_time, end_session_naive).tz_localize(tzinfo),
                 algorithm_returns=algorithm_returns,
                 benchmark_returns=benchmark_returns,
                 algorithm_leverages=algorithm_leverages,


### PR DESCRIPTION
## Summary

Closes #319

- Fix `DataFrame.tz_localize()` removal in pandas 2.0+ (benchmarks.py)
- Guard `np.isnan()` for integer dtypes (hdf5_daily_bars.py)
- Replace `DatetimeIndex.freq` with index-based lookups / `tc.day` (bcolz_minute_bars.py, continuous_future_reader.py)
- Fix tz-naive vs tz-aware comparison in `_ClassicRiskMetrics._periods_in_range`
- Replace deprecated `pd.Timestamp.utcnow()` with `.now("UTC")`

## Test plan

- [ ] All existing tests pass (3149 passed, only pre-existing pandas 2.3 compat failures in ewm/MACD)
- [ ] `flake8 src/zipline tests` passes clean
- [ ] Verify benchmark loading with tz-aware CSV files
- [ ] Verify HDF5 daily bar reading with volume fields