### PR TITLE
Fix DataPortal correctness bugs

### DIFF
--- a/docs/source/whatsnew/skeleton.txt
+++ b/docs/source/whatsnew/skeleton.txt
@@ -31,7 +31,10 @@ None
 Bug Fixes
 ~~~~~~~~~
 
-None
+- Fix ``DataPortal._first_trading_minute`` set to ``(None, None)`` tuple instead
+  of ``None`` when no first trading day is configured (:issue:`xxx`).
+- Fix ``DataPortal._get_daily_spot_value`` passing ``"minute"`` instead of
+  ``"daily"`` as data frequency to ``get_adjusted_value`` (:issue:`xxx`).
 
 Performance
 ~~~~~~~~~~~

--- a/src/zipline/data/data_portal.py
+++ b/src/zipline/data/data_portal.py
@@ -273,7 +273,7 @@ class DataPortal:
         self._first_trading_minute = (
             self.trading_calendar.session_first_minute(self._first_trading_day)
             if self._first_trading_day is not None
-            else (None, None)
+            else None
         )
 
         # Store the locs of the first day and first minute
@@ -734,7 +734,7 @@ class DataPortal:
                         else:
                             # adjust if needed
                             return self.get_adjusted_value(
-                                asset, column, found_dt, dt, "minute", spot_value=value
+                                asset, column, found_dt, dt, "daily", spot_value=value
                             )
                     else:
                         found_dt -= self.trading_calendar.day


### PR DESCRIPTION
## Summary

Closes #320

- Fix `_first_trading_minute` set to `(None, None)` tuple instead of `None`
- Fix `_get_daily_spot_value` passing `"minute"` instead of `"daily"` to `get_adjusted_value`

## Test plan

- [ ] All existing tests pass
- [ ] `flake8 src/zipline/data/data_portal.py` passes clean
- [ ] Verify minute history window works when `first_trading_day` is None
- [ ] Verify daily price forward-fill uses correct adjustment frequency