### PR TITLE
Fix simulation edge cases in slippage, controls, and metrics

### DIFF
--- a/docs/source/whatsnew/skeleton.txt
+++ b/docs/source/whatsnew/skeleton.txt
@@ -31,7 +31,13 @@ None
 Bug Fixes
 ~~~~~~~~~
 
-None
+- Fix ``fill_price_worse_than_limit_price`` skipping limit price check when
+  ``order.limit`` is ``0.0`` due to Python truthiness (:issue:`xxx`).
+- Fix ``Positions`` metric class calling ``ledger.positions`` property as a method
+  (:issue:`xxx`).
+- Fix multiple Python truthiness checks that should use ``is not None`` in
+  ``validate_order_params``, ``_can_order_asset``, ``AssetDateBounds.validate``,
+  ``MaxOrderSize``, and ``MaxPositionSize`` (:issue:`xxx`).
 
 Performance
 ~~~~~~~~~~~

--- a/src/zipline/algorithm.py
+++ b/src/zipline/algorithm.py
@@ -1193,7 +1193,7 @@ class TradingAlgorithm:
                 " Use 'sid()' or 'symbol()' methods to look up an Asset."
             )
 
-        if asset.auto_close_date:
+        if asset.auto_close_date is not None:
             # TODO FIXME TZ MESS
             day = self.trading_calendar.minute_to_session(self.get_datetime())
 
@@ -1300,7 +1300,7 @@ class TradingAlgorithm:
                 msg="order() can only be called from within handle_data()"
             )
 
-        if style:
+        if style is not None:
             if limit_price:
                 raise UnsupportedOrderParameters(
                     msg="Passing both limit_price and style is not supported."

--- a/src/zipline/finance/controls.py
+++ b/src/zipline/finance/controls.py
@@ -155,10 +155,10 @@ class MaxOrderSize(TradingControl):
         if max_shares is None and max_notional is None:
             raise ValueError("Must supply at least one of max_shares and max_notional")
 
-        if max_shares and max_shares < 0:
+        if max_shares is not None and max_shares < 0:
             raise ValueError("max_shares cannot be negative.")
 
-        if max_notional and max_notional < 0:
+        if max_notional is not None and max_notional < 0:
             raise ValueError("max_notional must be positive.")
 
     def validate(self, asset, amount, portfolio, algo_datetime, algo_current_data):
@@ -199,10 +199,10 @@ class MaxPositionSize(TradingControl):
         if max_shares is None and max_notional is None:
             raise ValueError("Must supply at least one of max_shares and max_notional")
 
-        if max_shares and max_shares < 0:
+        if max_shares is not None and max_shares < 0:
             raise ValueError("max_shares cannot be negative.")
 
-        if max_notional and max_notional < 0:
+        if max_notional is not None and max_notional < 0:
             raise ValueError("max_notional must be positive.")
 
     def validate(self, asset, amount, portfolio, algo_datetime, algo_current_data):
@@ -268,13 +268,13 @@ class AssetDateBounds(TradingControl):
         normalized_algo_dt = algo_datetime.normalize().tz_localize(None)
 
         # Fail if the algo is before this Asset's start_date
-        if asset.start_date:
+        if asset.start_date is not None:
             normalized_start = asset.start_date.normalize()
             if normalized_algo_dt < normalized_start:
                 metadata = {"asset_start_date": normalized_start}
                 self.handle_violation(asset, amount, algo_datetime, metadata=metadata)
         # Fail if the algo has passed this Asset's end_date
-        if asset.end_date:
+        if asset.end_date is not None:
             normalized_end = asset.end_date.normalize()
             if normalized_algo_dt > normalized_end:
                 metadata = {"asset_end_date": normalized_end}

--- a/src/zipline/finance/metrics/metric.py
+++ b/src/zipline/finance/metrics/metric.py
@@ -277,10 +277,10 @@ class Positions:
     """Tracks daily positions."""
 
     def end_of_bar(self, packet, ledger, dt, session_ix, data_portal):
-        packet["minute_perf"]["positions"] = ledger.positions(dt)
+        packet["minute_perf"]["positions"] = ledger.positions
 
     def end_of_session(self, packet, ledger, dt, session_ix, data_portal):
-        packet["daily_perf"]["positions"] = ledger.positions()
+        packet["daily_perf"]["positions"] = ledger.positions
 
 
 class ReturnsStatistic:

--- a/src/zipline/finance/slippage.py
+++ b/src/zipline/finance/slippage.py
@@ -61,7 +61,7 @@ def fill_price_worse_than_limit_price(fill_price, order):
     bool: Whether the fill price is above the limit price (for a buy) or below
     the limit price (for a sell).
     """
-    if order.limit:
+    if order.limit is not None:
         # this is tricky! if an order with a limit price has reached
         # the limit price, we will try to fill the order. do not fill
         # these shares if the impacted price is worse than the limit


### PR DESCRIPTION
## Summary

Closes #321

- Fix `order.limit` truthiness check in `fill_price_worse_than_limit_price`
- Fix `Positions` metric calling `ledger.positions` property as method
- Fix `validate_order_params` style truthiness check
- Fix `_can_order_asset` auto_close_date truthiness check
- Fix `AssetDateBounds.validate` start_date/end_date truthiness checks
- Fix `MaxOrderSize`/`MaxPositionSize` validation truthiness checks

All changes follow the pattern already used correctly in `Order.check_order_triggers`: `if self.stop is not None:`.

## Test plan

- [ ] All existing tests pass
- [ ] `flake8` passes on modified files
- [ ] Verify limit orders with price=0.0 are handled correctly
- [ ] Verify `Positions` metric works in minute-emission mode