### PR TITLE
Fix misc minor bugs in roll finder, HDF5, pipeline, adjustments, and metrics

### DIFF
--- a/docs/source/whatsnew/skeleton.txt
+++ b/docs/source/whatsnew/skeleton.txt
@@ -31,7 +31,18 @@ None
 Bug Fixes
 ~~~~~~~~~
 
-None
+- Fix ``RollFinder.get_rolls`` using ``sessions.freq`` which returns ``None``
+  in pandas 2.0+ (:issue:`xxx`).
+- Fix ``compute_asset_lifetimes`` reporting all-null assets as spanning the entire
+  date range in HDF5 daily bar writer (:issue:`xxx`).
+- Fix ``NumericalExpression._compute`` not applying mask to output (:issue:`xxx`).
+- Fix ``NumericalExpression._merge_expressions`` using ``set()`` which loses
+  deterministic input ordering (:issue:`xxx`).
+- Add SQL table name whitelist validation in ``SQLiteAdjustmentReader``
+  (:issue:`xxx`).
+- Fix ``_ClassicRiskMetrics.risk_metric_period`` computing ``max_leverage`` across
+  the entire simulation instead of filtering to the reporting period
+  (:issue:`xxx`).
 
 Performance
 ~~~~~~~~~~~

--- a/src/zipline/assets/roll_finder.py
+++ b/src/zipline/assets/roll_finder.py
@@ -99,7 +99,7 @@ class RollFinder(ABC):
         sessions = tc.sessions_in_range(
             tc.minute_to_session(start), tc.minute_to_session(end)
         )
-        freq = sessions.freq
+        freq = tc.day
         if first == front:
             # This is a bit tricky to grasp. Once we have the active contract
             # on the given end date, we want to start walking backwards towards

--- a/src/zipline/data/adjustments.py
+++ b/src/zipline/data/adjustments.py
@@ -209,6 +209,11 @@ class SQLiteAdjustmentReader:
         ]
 
     def get_adjustments_for_sid(self, table_name, sid):
+        if table_name.lower() not in SQLITE_ADJUSTMENT_TABLENAMES:
+            raise ValueError(
+                f"Table name '{table_name}' is not in the whitelist of "
+                f"adjustment tables: {SQLITE_ADJUSTMENT_TABLENAMES}"
+            )
         t = (sid,)
         c = self.conn.cursor()
         adjustments_for_sid = c.execute(

--- a/src/zipline/data/hdf5_daily_bars.py
+++ b/src/zipline/data/hdf5_daily_bars.py
@@ -452,6 +452,12 @@ def compute_asset_lifetimes(frames):
     # Offset of the last null from the start of the input
     end_date_ixs = is_null_matrix.shape[0] - end_offsets - 1
 
+    # For all-null assets, argmin returns 0, making them appear to span the
+    # entire date range. Set start > end so they are never in-lifetime.
+    all_null = is_null_matrix.all(axis=0)
+    start_date_ixs[all_null] = is_null_matrix.shape[0] - 1
+    end_date_ixs[all_null] = 0
+
     return start_date_ixs, end_date_ixs
 
 

--- a/src/zipline/finance/metrics/metric.py
+++ b/src/zipline/finance/metrics/metric.py
@@ -465,6 +465,14 @@ class _ClassicRiskMetrics:
             & (algorithm_returns.index <= end_session)
         ]
 
+        if isinstance(
+            getattr(algorithm_leverages, 'index', None), pd.DatetimeIndex
+        ):
+            algorithm_leverages = algorithm_leverages[
+                (algorithm_leverages.index >= start_session)
+                & (algorithm_leverages.index <= end_session)
+            ]
+
         # Benchmark needs to be masked to the same dates as the algo returns
         benchmark_ret_tzinfo = benchmark_returns.index.tzinfo
         benchmark_returns = benchmark_returns[
@@ -596,6 +604,6 @@ class _ClassicRiskMetrics:
                     sessions[0],
                     sessions[-1],
                 ),
-                algorithm_leverages=self._leverages,
+                algorithm_leverages=pd.Series(self._leverages, index=sessions),
             )
         )

--- a/src/zipline/pipeline/expression.py
+++ b/src/zipline/pipeline/expression.py
@@ -252,6 +252,7 @@ class NumericalExpression(ComputableTerm):
             global_dict={"inf": inf},
             out=out,
         )
+        out[~mask] = self.missing_value
         return out
 
     def _rebind_variables(self, new_inputs):
@@ -288,7 +289,7 @@ class NumericalExpression(ComputableTerm):
 
         Returns a tuple of (new_self_expr, new_other_expr, new_inputs)
         """
-        new_inputs = tuple(set(self.inputs).union(other.inputs))
+        new_inputs = tuple(dict.fromkeys(self.inputs + other.inputs))
         new_self_expr = self._rebind_variables(new_inputs)
         new_other_expr = other._rebind_variables(new_inputs)
         return new_self_expr, new_other_expr, new_inputs


### PR DESCRIPTION
## Summary

Closes #322

- Replace `sessions.freq` with `tc.day` in `RollFinder.get_rolls`
- Fix `compute_asset_lifetimes` for all-null assets (set start > end)
- Apply mask to `NumericalExpression._compute` output
- Preserve input ordering in `_merge_expressions` with `dict.fromkeys`
- Add SQL table name whitelist validation in `SQLiteAdjustmentReader`
- Filter `max_leverage` to reporting period in `_ClassicRiskMetrics`

## Test plan

- [ ] All existing tests pass
- [ ] `flake8` passes on modified files
- [ ] Verify pipeline expressions with masked assets produce correct missing values
- [ ] Verify risk metrics report per-period max leverage, not global